### PR TITLE
Feat - allow explicit deploy to a specific env

### DIFF
--- a/toolsets/aws/aws-eb-deploy
+++ b/toolsets/aws/aws-eb-deploy
@@ -1,4 +1,4 @@
 #!/bin/bash
 . "$HAM_HOME/bin/ham-bash-lib.sh"
 git tag aws_deploy_`tag_date`
-aws-eb deploy
+aws-eb deploy $*


### PR DESCRIPTION
Otherwise we can't deploy to different beanstalk envs using same branch.

Usage:

```
$ aws-eb-deploy storeviva-dp-staging-master
$ aws-eb-deploy storeviva-dp-staging-web
$ aws-eb-deploy storeviva-dp-staging-worker
```
