### PR TITLE
Install graphdoc

### DIFF
--- a/toolsets/nodejs/npm-install-global-deps
+++ b/toolsets/nodejs/npm-install-global-deps
@@ -2,7 +2,7 @@
 . ham-bash-lib.sh
 . hat default python_27 nodejs
 # On separated lines because npm onlyshows a spinner... so you have no idea how long things will take...
-NUM_PACKAGES=27
+NUM_PACKAGES=28
 NPM_INSTALL_BIN="npm install -g"
 NPM_INSTALL="npm install -g --no-bin-links"
 echo "I/Installing package 'node-pre-gyp' (0/$NUM_PACKAGES)"
@@ -61,3 +61,5 @@ echo "I/Installing package 'jsonlint' (26/$NUM_PACKAGES)"
 ${NPM_INSTALL_BIN} jsonlint@1.6.x
 echo "I/Installing package 'eslint-plugin-promise' (27/$NUM_PACKAGES)"
 ${NPM_INSTALL} eslint-plugin-promise@3.5.x
+echo "I/Installing package '@2fd/graphdoc' (28/$NUM_PACKAGES)"
+${NPM_INSTALL_BIN} @2fd/graphdoc@2.4.x


### PR DESCRIPTION
Such that `graphdoc` is available after:

```
$ source ham-toolset nodejs
$ npm-install-global-deps
```