### PR TITLE
Linux also has `which`; local doppler

### DIFF
--- a/bin/where_inpath
+++ b/bin/where_inpath
@@ -8,7 +8,7 @@ case $HAM_OS in
     NT*)
         path=$("type" -p "$*")
         ;;
-    OSX*)
+    OSX* | LINUX*)
         path=$("which" "$*")
         ;;
     *)

--- a/specs/toolsets/secrets_doppler/setup-toolset.sh
+++ b/specs/toolsets/secrets_doppler/setup-toolset.sh
@@ -17,6 +17,23 @@ case $HAM_OS in
             fi
         fi
         ;;
+    LINUX*)
+        if [ -z "`which doppler`" ]; then
+            echo "I/Downloading doppler .deb package"
+            curl -Ls --tlsv1.2 --proto "=https" --retry 3 https://github.com/DopplerHQ/cli/releases/download/3.38.0/doppler_3.38.0_linux_amd64.deb -O doppler_3.38.0_linux_amd64.deb
+	    echo "I/Unpacking deb package locally"
+	    #assuming dpkg is available
+	    dpkg -x doppler_3.38.0_linux_amd64.deb ${HAM_TOOLSET_DIR}
+	    rm doppler_3.38.0_linux_amd64.deb
+	    export PATH="${HAM_TOOLSET_DIR}/usr/bin":${PATH}
+
+            if [ -z "`which doppler`" ]; then
+                echo "E/Can't install doppler."
+                return 1
+            fi
+        fi
+        ;;
+
     *)
         echo "E/Toolset: Unsupported host OS"
         return 1


### PR DESCRIPTION
Linux also has `which` and `whereis` never outputs an empty string

On debian-based systems, just unpack the .deb file -- it has a single binary which works out of the box.