### PR TITLE
toolsets/emscripten: Added Linux support for emscripten toolset

### DIFF
--- a/specs/toolsets/emscripten/setup-toolset.sh
+++ b/specs/toolsets/emscripten/setup-toolset.sh
@@ -24,6 +24,15 @@ case $HAM_OS in
         export PATH=${HAM_TOOLSET_DIR}:${PATH}
         export BUILD_BIN_LOA=$HAM_BIN_LOA
         ;;
+    LINUX*)
+        if [ -z `which emcc` ]; then
+            export HAM_ENABLE_EXPERIMENTAL_LINUX_BREW=1
+            echo "W/Couldn't find emcc, will try to install it with brew."
+            ham-brew install emscripten
+        fi
+        export PATH=${HAM_TOOLSET_DIR}:${PATH}
+        export BUILD_BIN_LOA=$HAM_BIN_LOA
+        ;;
     *)
         echo "E/Toolset: Unsupported host OS"
         return 1


### PR DESCRIPTION
## Formal Notes
This PR fixes:
* NRN: Added emscripten toolset for linux

## Description, Motivation and Context
Emscripten toolset was not configured for Linux. I added it by using the ham-brew to install it. It is supposed to be experimental  but so far it works (but it takes foreeeeeeveeeer).

## How Has This Been Tested?
Load the toolset with:
```
. hat emscripten
```
Then you compile normally and check that it went into the `bin/web-js`

## Types of changes

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that cause existing functionality to change)
* [ ] Documentation (code docs, comments, or changes to the doc systems)
* [x] Testing/Build (test coverage or the test/build subsystems themselves)
* [ ] Packaging (adds examples or modifies a release package)

<!---
- This template is stored in .github/PULL_REQUEST_TEMPLATE.md
-->
