### PR TITLE
thrift_cppm: Build the thrift compiler ;

### DIFF
--- a/_run_ci.sh
+++ b/_run_ci.sh
@@ -16,3 +16,22 @@ echo "I/Build and run pi with ham"
 (set -x;
  cd "$HAM_HOME/sources/ham/tests/pi" ;
  ham Run_pi)
+
+echo "I/Build cppm modules."
+case $HAM_OS in
+    NT*)
+        echo "W/thrift_cppm module not supported yet on Windows."
+        ;;
+    OSX*)
+        (set -x ;
+         ham-cppm-build thrift_cppm)
+        ;;
+    LINUX*)
+        (set -x ;
+         ham-cppm-build thrift_cppm)
+        ;;
+    *)
+        echo "E/Toolset: Unsupported host OS"
+        return 1
+        ;;
+esac

--- a/bin/ham-bash-lib.sh
+++ b/bin/ham-bash-lib.sh
@@ -95,6 +95,9 @@ die()
 }
 
 errcheck()
+# usage:
+#   errcheck errorcode ModuleName "Message Saying Why"
+#   errcheck $? $HAM_TOOLSET_NAME "Message Saying Why" || return 1
 {
   if [ $1 != 0 ]
   then
@@ -109,6 +112,50 @@ retcheck()
     complain "$@"
     return 1
   fi
+}
+
+#
+# check_file PATH (nope)
+#
+# 'nope' can be used to skip file check without writting a bunch of tests. For
+# example you can set the PATH to 'nocheck' and pass 'nocheck' to nope and the
+# check will be skipped instead of failing. This is useful when the list of
+# files is built in the script before the checks are run, you can write
+# 'nocheck' in the list and know that the check will be skipped afterward.
+#
+# return 1 if the file doesn't exist
+#
+check_file() {
+  PATH=$1
+  NOPE=$2
+  # echo "... check_file: $NOPE :: $PATH"
+
+  if [ -n "$NOPE" ] && [ "$NOPE" == "$PATH" ]; then
+    # Nocheck
+    echo "ok-nocheck"
+    return 0
+  elif [ -e "$PATH" ]; then
+    # File exists
+    echo "ok-exists"
+    return 0
+  else
+    # File doesnt exists
+    echo "notfound"
+    return 1
+  fi
+}
+
+errcheck_file()
+# usage:
+#   errcheck_file ModuleName FILE_PATH
+#   errcheck_file $HAM_TOOLSET_NAME some_file_path.lib || return 1
+{
+    MODULE_NAME="$1"
+    FILE_PATH="$2"
+    CHECK_FILE=$(check_file "$FILE_PATH")
+    if [ "$CHECK_FILE" == "notfound" ]; then
+        die "$MODULE_NAME" "Check file failed: $CHECK_FILE: '$FILE_PATH'."
+    fi
 }
 
 nativedir()

--- a/bin/ham-cppm-build-check
+++ b/bin/ham-cppm-build-check
@@ -4,10 +4,14 @@ if [[ -z "$HAM_HOME" ]]; then echo "E/HAM_HOME not set !"; exit 1; fi
 
 usage() {
     echo "usage:"
-    echo "  ${0##*/} TOOLSET HDR(path.h|noheader) (nolib) (nodll)"
+    echo "  ${0##*/} TOOLSET HDR(path.h|noheader) libname|nolib dllname|nodll (exe_path0 ... exe_pathN)"
     echo ""
     echo "example:"
-    echo "  ham-cppm-build thrift_cppm all"
+    echo "  ham-cppm-build-check thrift_cppm noheader thrift_cppm thrift_cppm ham_thriftc"
+    echo ""
+    echo "note:"
+    echo "  Setting HAM_CPPM_FORCE_BUILD to 1 will skip the checks and will always try to build."
+    echo ""
     exit 1
 }
 
@@ -20,6 +24,9 @@ TOOLSET=$1
 if [ -z "$TOOLSET" ]; then
   echo "E/No TOOLSET specified"
   usage
+elif [ ! -d "$HAM_HOME/specs/toolsets/$TOOLSET" ]; then
+  echo "E/TOOLSET doesn't exist: '$HAM_HOME/specs/toolsets/$TOOLSET'."
+  usage
 fi
 shift
 
@@ -29,22 +36,31 @@ if [ -z "$HDR_CHECK_PATH" ]; then
   usage
 fi
 shift
+# echo "I/HDR_CHECK_PATH: $HDR_CHECK_PATH"
 
-LIB_CHECK_PATH=
-if [ "$1" == "nolib" ]; then
-  shift
+LIB_CHECK_PATH=$1
+if [ -z "$LIB_CHECK_PATH" ]; then
+  echo "E/No LIB_CHECK_PATH specified"
+  usage
+elif [ "$1" == "nolib" ]; then
   LIB_CHECK_PATH=nolib
 else
-  LIB_CHECK_PATH="${HAM_HOME}/libs/`ham-cppm-bin-filepath lib ${TOOLSET}_${BUILD}`"
+  LIB_CHECK_PATH="${HAM_HOME}/libs/`ham-cppm-bin-filepath lib ${LIB_CHECK_PATH}_${BUILD}`"
 fi
+shift
+# echo "I/LIB_CHECK_PATH: $LIB_CHECK_PATH"
 
-DLL_CHECK_PATH=
-if [ "$1" == "nodll" ]; then
-  shift
+DLL_CHECK_PATH=$1
+if [ -z "$DLL_CHECK_PATH" ]; then
+  echo "E/No DLL_CHECK_PATH specified"
+  usage
+elif [ "$1" == "nodll" ]; then
   DLL_CHECK_PATH=nodll
 else
-  DLL_CHECK_PATH="${HAM_HOME}/bin/`ham-cppm-bin-filepath dll ${TOOLSET}_${BUILD}`"
+  DLL_CHECK_PATH="${HAM_HOME}/bin/`ham-cppm-bin-filepath dll ${DLL_CHECK_PATH}_${BUILD}`"
 fi
+shift
+# echo "I/DLL_CHECK_PATH: $DLL_CHECK_PATH"
 
 # Platform specific skips
 # echo "... BIN_LOA: $BIN_LOA"
@@ -55,45 +71,58 @@ case $BIN_LOA in
     ;;
 esac
 
-# check_file PATH nodll|noheader|nolib
-function check_file() {
-  NOPE=$2
-  PATH=$1
-  # echo "... check_file: $NOPE :: $PATH"
-
-  if [ "$NOPE" == "$PATH" ]; then
-    # Nocheck
-    echo "ok-nocheck"
-  elif [ -e "$PATH" ]; then
-    # File exists
-    echo "ok-exists"
-  else
-    # File doesnt exists
-    echo "notfound"
-  fi
-}
-
-# check_file $HDR_CHECK_PATH noheader
-# check_file $LIB_CHECK_PATH nolib
-# check_file $DLL_CHECK_PATH nodll
-
-if [ "$(check_file $HDR_CHECK_PATH noheader)" == "notfound" ] ||
+EXE_FILES=()
+if [ "$HAM_CPPM_FORCE_BUILD" == "1" ] ||
+     [ "$(check_file $HDR_CHECK_PATH noheader)" == "notfound" ] ||
      [ "$(check_file $LIB_CHECK_PATH nolib)" == "notfound" ] ||
      [ "$(check_file $DLL_CHECK_PATH nodll)" == "notfound" ]; then
-  (set -x ; HAM_NO_VER_CHECK=1 ham-cppm-build $TOOLSET)
+  SHOULD_BUILD=1
+else
+  SHOULD_BUILD=0
+fi
 
+if [ "$SHOULD_BUILD" == "0" ]; then
+  while [ "$#" -gt 0 ]; do
+    EXE_PATH=$(ham-cppm-exe-path $TOOLSET $1)
+    # echo "I/EXE_PATH: $EXE_PATH"
+    EXE_FILES+=("$EXE_PATH")
+    if [ ! -e "$EXE_PATH" ]; then
+      SHOULD_BUILD=1
+      break
+    fi
+    shift
+  done
+fi
+# echo "I/SHOULD_BUILD: $SHOULD_BUILD"
+
+if [ "$SHOULD_BUILD" == "1" ]; then
+  (set -x ; HAM_NO_VER_CHECK=1 BUILD=$BUILD ham-cppm-build $TOOLSET)
+
+  FAILED=0
   if [ "$(check_file $HDR_CHECK_PATH noheader)" == "notfound" ]; then
     echo "E/Can't find build artifact header '$HDR_CHECK_PATH'."
-    exit 1
+    FAILED=1
   fi
 
   if [ "$(check_file $LIB_CHECK_PATH nolib)" == "notfound" ]; then
     echo "E/Can't find build artifact lib '$LIB_CHECK_PATH'."
-    exit 1
+    FAILED=1
   fi
 
   if [ "$(check_file $DLL_CHECK_PATH nodll)" == "notfound" ]; then
     echo "E/Can't find build artifact dll '$DLL_CHECK_PATH'."
+    FAILED=1
+  fi
+
+  for EXE_FILE in "${EXE_FILES[@]}"; do
+    if [ ! -e "$EXE_FILE" ]; then
+      echo "E/Can't find build artifact exe '$EXE_FILE'."
+      FAILED=1
+    fi
+  done
+
+  if [ "$FAILED" == 1 ]; then
+    echo "E/Not all required artifacts of $TOOLSET could be built."
     exit 1
   fi
 fi

--- a/bin/ham-cppm-exe-path
+++ b/bin/ham-cppm-exe-path
@@ -1,0 +1,37 @@
+#!/bin/bash -e
+if [[ -z "$HAM_HOME" ]]; then echo "E/HAM_HOME not set !"; exit 1; fi
+. "$HAM_HOME/bin/ham-bash-setenv.sh"
+
+usage() {
+    echo "usage:"
+    echo "  ${0##*/} TOOLSET EXE_TARGET_NAME"
+    echo ""
+    echo "example:"
+    echo "  ham-cppm-exe-path thrift_cppm ham_thriftc"
+    exit 1
+}
+
+# Build settings
+export BUILD=${BUILD:-ra}
+export BIN_LOA=${HAM_TARGET_BIN_LOA:-$HAM_BIN_LOA}
+
+# Parameters check
+TOOLSET=$1
+if [ -z "$TOOLSET" ]; then
+  echo "E/No TOOLSET specified"
+  usage
+# elif [ ! -d "$HAM_HOME/specs/toolsets/$TOOLSET" ]; then
+  # echo "E/TOOLSET doesn't exist: '$HAM_HOME/specs/toolsets/$TOOLSET'."
+  # usage
+fi
+shift
+
+EXE_TARGET_NAME=$1
+if [ -z "$EXE_TARGET_NAME" ]; then
+  echo "E/No EXE_TARGET_NAME specified"
+  usage
+fi
+shift
+
+EXE_PATH="$HAM_HOME/bin/$(ham-cppm-bin-filepath exe ${EXE_TARGET_NAME}_${BUILD})"
+echo "$EXE_PATH"

--- a/bin/ham-env-clear
+++ b/bin/ham-env-clear
@@ -1,5 +1,5 @@
 #!/bin/bash
-TO_UNSET="`ham-env | grep -E -vw 'WORK|HAM_OS|HAM_HOME|HAM_CMD|HAM_BIN_LOA|HAM_NO_VER_CHECK|BUILD_TARGET' | cut -d= -f1`"
+TO_UNSET="`ham-env | grep -E -vw 'WORK|HAM_OS|HAM_HOME|HAM_CMD|HAM_BIN_LOA|HAM_NO_VER_CHECK|HAM_CPPM_FORCE_BUILD|BUILD_TARGET' | cut -d= -f1`"
 # echo "TO_UNSET: $TO_UNSET"
 unset $TO_UNSET
 . "$HAM_HOME/bin/ham-bash-setenv.sh"

--- a/bin/ham-lint
+++ b/bin/ham-lint
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 if [[ -z "$HAM_HOME" ]]; then echo "E/HAM_HOME not set !"; exit 1; fi
 . "$HAM_HOME/bin/ham-bash-setenv.sh"
 ham-run-up _lint.sh $@

--- a/bin/ham-lint-lib.sh
+++ b/bin/ham-lint-lib.sh
@@ -1,0 +1,243 @@
+#!/bin/bash -e
+export HAM_NO_VER_CHECK=1
+if [[ -z "$HAM_HOME" ]]; then echo "E/HAM_HOME not set !"; exit 1; fi
+. "$HAM_HOME/bin/ham-bash-setenv.sh"
+
+function ni_lint() {
+    DIR=`pwd`
+    if [ -z "$1" ]; then
+        FILES=$(find . -name "*.ni" -o -name "*.nip" -o -name "*.niw")
+    else
+        FILES="$@"
+    fi
+
+    for f in $FILES
+    do
+        ni -c "$DIR/$f"
+    done
+}
+
+function ham_flymake_lint() {
+    # ham-flymake FLYMAKE=1 CHK_SOURCES=_Test_TiledWidget_aflymake.cpp FLYMAKE_BASEDIR=./ check-syntax
+    DIR=$(dirname $1)
+    FILENAME=$(basename "$1")
+    # We can't just rename the file because VScode won't be able to map the file
+    # to the original one. We could add a #line directive in the renamed file
+    # but it's not worth it as their's probably edge cases where it won't work
+    # and be a pain to track down.
+    # FLYMAKE_FILENAME=_${FILENAME%.*}_aflymake.${FILENAME##*.}
+    (set -ex;
+     cd "$DIR"
+     # cp "$FILENAME" "$FLYMAKE_FILENAME"
+     touch "$FILENAME"
+     ham-flymake FLYMAKE=1 CHK_SOURCES="$FILENAME" FLYMAKE_BASEDIR="./" check-syntax
+     # rm "$FLYMAKE_FILENAME"
+     )
+}
+
+function cpp_lint_dir() {
+    DIR=$1
+    shift
+    echo "I/cpp_lint_dir: '$DIR'"
+    (set -e ;
+     find "$DIR" \
+          \( -name '*.c' \
+          -o -name '*.cc' \
+          -o -name '*.cpp' \
+          -o -name '*.h' \
+          -o -name '*.hh' \
+          -o -name '*.hpp' \
+          -o -name '*.inl' \
+          ! -iname '*.idl.inl' \
+          \) -print0 |\
+         xargs -t -0 -n 10 -P ${HAM_NUM_JOBS:-8} run-for-xargs clang-format $@) || return 1
+}
+
+function cpp_lint() {
+    if [ "$LINT_FORMAT" == "yes" ] || [ "$LINT_FIX" == "yes" ]; then
+        PARAMS=(-i)
+    else
+        PARAMS=(--dry-run -Werror)
+    fi
+
+    if [ -z "$1" ]; then
+        DIR=`pwd`
+        cpp_lint_dir "$DIR" ${PARAMS[@]}
+    else
+        (set -x; clang-format ${PARAMS[@]} "$1")
+        ham_flymake_lint "$1"
+    fi
+}
+
+function js_lint() {
+    toolset_import_once nodejs > /dev/null
+    FIX_OPT=
+    if [ "$LINT_FIX" == "yes" ]; then
+        FIX_OPT=--fix
+    fi
+
+    ESLINT_TARGET="${1:-$LINT_JS_DIR}" # Use $1 or $LINT_JS_DIR
+    ESLINT_TARGET="${ESLINT_TARGET:-./resources/js}" # If not specified default to ./resources/js
+    (set -x; eslint $FIX_OPT --max-warnings=0 --ext .js --ext .jsx --ext .mjs --ext .cjs "$ESLINT_TARGET")
+}
+
+function php_lint() {
+    toolset_import_once php > /dev/null
+    if [ "$LINT_FIX" == "yes" ]; then
+        if [ -z "$1" ]; then
+            (set -x; ./tools/php-cs-fixer/vendor/bin/php-cs-fixer fix .)
+        else
+            (set -x; ./tools/php-cs-fixer/vendor/bin/php-cs-fixer fix "$1")
+        fi
+    fi
+    if [ -z "$1" ]; then
+        (set -x; ./vendor/bin/phpstan analyse --memory-limit=8000M)
+    else
+        (set -x; ./vendor/bin/phpstan analyse --memory-limit=8000M --error-format=raw "$1")
+    fi
+}
+
+function rust_lint() {
+    toolset_import_once rust > /dev/null
+
+    # Allow some lints
+    # CLIPPYFLAGS="-A clippy::bool_comparison"
+
+    if [ "$LINT_FIX" == "yes" ]; then
+        # Cargo fix can't be run on a single file...
+        (set -x; cargo clippy --fix --allow-dirty --allow-staged -- $CLIPPYFLAGS)
+    else
+        # Cargo clippy can't be run on a single file...
+        (set -x; cargo clippy -- $CLIPPYFLAGS)
+    fi
+
+    # Format after
+    if [ "$LINT_FORMAT" == "yes" ]; then
+        if [ -z "$1" ]; then
+            (set -x; cargo fmt)
+        else
+            (set -x; rustfmt "$1")
+        fi
+    fi
+}
+
+function lint_file() {
+    CMD="$1"
+    EXT="${CMD##*.}"
+    case "$EXT" in
+        c|cc|cpp|cxx|h|hh|hpp|hxx|inl)
+            cpp_lint "$CMD"
+            errcheck $? cpp_lint "Single cpp file lint failed in '$DIRNAME'."
+            ;;
+        cni|cpp2)
+            ham_flymake_lint "$CMD"
+            errcheck $? cpp_lint "Single cpp2 file lint failed in '$DIRNAME'."
+            ;;
+        php)
+            php_lint "$CMD"
+            errcheck $? php_lint "Single php file lint failed in '$DIRNAME'."
+            ;;
+        rs)
+            rust_lint "$CMD"
+            errcheck $? rust_lint "Single rust file lint failed in '$DIRNAME'."
+            ;;
+        js|jsx|mjs|cjs)
+            js_lint "$CMD"
+            errcheck $? js_lint "Single js file lint failed in '$DIRNAME'."
+            ;;
+        ni|nip|niw)
+            ni_lint "$CMD"
+            errcheck $? ni_lint "Single ni file lint failed in '$DIRNAME'."
+            ;;
+        *)
+            die "Unsupported extension '$EXT' for '$CMD' in '$DIRNAME'."
+            ;;
+    esac
+}
+
+function lint_dir() {
+    LANG=$1
+    DIRNAME=$2
+    if [ ! -d "$DIRNAME" ]; then
+        echo "E/no directory '$DIRNAME' specified after '${LANG}'."
+        return 1
+    fi
+    shift
+    echo "I/${LANG}_lint all in '$DIRNAME'."
+    pushd "$DIRNAME" >> /dev/null
+    ${LANG}_lint
+    errcheck $? ${LANG}_lint "${LANG} files lint failed in '$DIRNAME'."
+    popd >> /dev/null
+}
+
+function all_lint() {
+    if [ -z "$1" ]; then
+        echo "E/Nothing to lint specified in '$DIRNAME'."
+        return 1
+    fi
+
+    while [ "$1" != "" ]; do
+        CMD="$1"
+        shift
+        case "$CMD" in
+            cpp)
+                (set -e ; lint_dir cpp $1)
+                shift
+                ;;
+            php)
+                (set -e ; lint_dir php $1)
+                shift
+                ;;
+            js)
+                (set -e ; lint_dir js $1)
+                shift
+                ;;
+            rust)
+                (set -e ; lint_dir rust $1)
+                shift
+                ;;
+            ni)
+                (set -e ; lint_dir ni $1)
+                shift
+                ;;
+            *)
+                lint_file $CMD
+                ;;
+        esac
+    done
+}
+
+function lint_sh_usage() {
+    echo "usage: ./_lint.sh (options) FILE_PATHS"
+    echo ""
+    echo "  --fix     If possible fix the problems detected during linting."
+    echo "  --format  If possible format the specified files."
+    echo ""
+    echo "  A directory can be checked at once by specifying the language"
+    echo "  follow by the directory path"
+    echo ""
+    echo "examples:"
+    echo "  ./_lint.sh sources/MyModule/MyThing.cpp"
+    echo "  ./_lint.sh cpp sources/MyModule/"
+    exit 1
+}
+
+function lint_sh_main() {
+    while [[ "$1" == "-"* ]]; do
+        if [ "$1" == "--fix" ]; then
+            shift
+            export LINT_FIX=yes
+        elif [ "$1" == "--format" ]; then
+            shift
+            export LINT_FORMAT=yes
+        else
+            die "Unknown lint option '$1'."
+        fi
+    done
+
+    if [ -z "$1" ]; then
+        lint_sh_usage
+    else
+        all_lint "$@"
+    fi
+}

--- a/bin/ham-run-up
+++ b/bin/ham-run-up
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 if [[ -z "$HAM_HOME" ]]; then echo "E/HAM_HOME not set !"; exit 1; fi
 . "$HAM_HOME/bin/ham-bash-setenv.sh"
 
@@ -19,10 +19,9 @@ shift
 
 EXE_PATH=$(ham-find-file-up "$EXE")
 if [ -e "$EXE_PATH" ]; then
-    echo "I/Running '$EXE_PATH'"
-    set -x
-    pwd
-    "$EXE_PATH" "$@"
+    echo "I/Running '$EXE_PATH'."
+    echo "I/In '$(pwd)'."
+    (set -x ; "$EXE_PATH" "$@")
 else
     echo "E/No '$EXE' found in any parent folder."
     exit 1

--- a/specs/_rules.ham
+++ b/specs/_rules.ham
@@ -4,5 +4,6 @@
 TK_NAME = "ham" ;
 TK_DIR = [ FGetAbsolutePath [ FDirName $(TOP) .. ] ] ;
 TOP_DIR = [ FDirName $(TK_DIR) specs ] ;
+TK_NONCE = 1 ;
 
 Import toolkit.ham ;

--- a/specs/toolsets/thrift_cppm/_build.ham
+++ b/specs/toolsets/thrift_cppm/_build.ham
@@ -107,3 +107,42 @@ if $(OS) = MACOSX {
   LINKLIBS on $(PKGTARGET) += -L$(OPENSSL_LIBDIR) -lcrypto -lssl ;
   ObjectHdrs $(BUILD_SRC) : [ FDirName $(OPENSSL_INCDIR) ] ;
 }
+
+### ham_thriftc #########################################################
+tkDefTool ham_thriftc : 1.0.0 ;
+
+SubDirHdrs $(SUBDIR) github-thrift compiler cpp src ;
+
+SRC =
+
+# gen'd by _gen_parser.sh
+[ tkPkgSrcSubDirLst [ FDirName github-thrift compiler cpp src thrift ] :
+  thrifty.cc
+  thriftl.cc
+]
+
+[ tkPkgSrcSubDirLst [ FDirName github-thrift compiler cpp src thrift ] :
+    common.cc
+]
+
+[ tkPkgSrcSubDirLst [ FDirName github-thrift compiler cpp src thrift generate ] :
+    t_generator.cc
+    validator_parser.cc
+]
+
+[ tkPkgSrcSubDirLst [ FDirName github-thrift compiler cpp src thrift parse ] :
+    t_typedef.cc
+    parse.cc
+]
+
+[ tkPkgSrcSubDirLst [ FDirName github-thrift compiler cpp src thrift ] :
+    main.cc
+]
+
+[ tkPkgSrcSubDirLst [ FDirName github-thrift compiler cpp src thrift audit ] :
+    t_audit.cpp
+]
+
+;
+
+BUILD_SRC = [ tkBuildPackage $(SRC) : pch minsz exc : $(CHK_SOURCES) : $(SRC_EXTRA) ] ;

--- a/specs/toolsets/thrift_cppm/_gen_parser.sh
+++ b/specs/toolsets/thrift_cppm/_gen_parser.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -ex
+mkdir -p ./github-thrift/compiler/cpp/src/thrift/gen/
+
+ham-brew-install bison "bin/bison"
+"$(ham-brew-installdir bison)/bin/bison" --output=./github-thrift/compiler/cpp/src/thrift/thrifty.cc --header=./github-thrift/compiler/cpp/src/thrift/thrifty.hh ./github-thrift/compiler/cpp/src/thrift/thrifty.yy
+
+ham-brew-install flex "bin/flex"
+"$(ham-brew-installdir flex)/bin/flex" -o ./github-thrift/compiler/cpp/src/thrift/thriftl.cc ./github-thrift/compiler/cpp/src/thrift/thriftl.ll

--- a/specs/toolsets/thrift_cppm/_ham_project
+++ b/specs/toolsets/thrift_cppm/_ham_project
@@ -5,6 +5,7 @@ if [[ -z $HAM_PROJECT_DIR ]]; then
 fi
 
 if [ ! -d "github-thrift" ]; then
+  toolset_import_list repos || return 1
   (set -x ; git clone --depth 1 https://github.com/bytecollider/thrift.git github-thrift)
 else
   echo "I/cppm-thrift: github-thrift already cloned"

--- a/specs/toolsets/thrift_cppm/setup-toolset.sh
+++ b/specs/toolsets/thrift_cppm/setup-toolset.sh
@@ -5,8 +5,9 @@ export HAM_TOOLSET_DIR="${HAM_HOME}/specs/toolsets/thrift_cppm"
 
 export HAM_HDRS_THRIFT_CPPM="${HAM_TOOLSET_DIR}/github-thrift/lib/cpp/src"
 
-ham-cppm-build-check thrift_cppm noheader || return 1
+ham-cppm-build-check thrift_cppm noheader thrift_cppm thrift_cppm ham_thriftc || return 1
 
-VER="--- thrift_cppm ---------------------"
+VER="--- thrift_cppm ---------------------
+$(`ham-cppm-exe-path thrift_cppm ham_thriftc` --version)"
 export HAM_TOOLSET_VERSIONS="$HAM_TOOLSET_VERSIONS
 $VER"


### PR DESCRIPTION
Builds the thrift compiler so that we can rely on a fixed version of thrift on all platforms.