### PR TITLE
James: ham: Add bash linting to top level of ham repo

### DIFF
--- a/_build.ham
+++ b/_build.ham
@@ -1,14 +1,93 @@
 SubDir TOP ;
 
-local BIN_DIR = [ FDirName $(TOP) bin ] ;
+local BIN_DIR = [ FDirName $(SUBDIR) bin ] ;
 # ECHO "... BIN_DIR:" $(BIN_DIR) ;
 
 # Recursively get all .sh files inside of bin/ directory
 local SH_FILES = [ FGristFiles [ ListFilesR $(BIN_DIR) : *.sh ] ] ;
-# Add all files at top level of bin/ directory with no file suffix
-SH_FILES += [ FGristFiles [ Match (^[^.]*$) : [ ListFiles $(BIN_DIR) ] ] ] ;
+
 # Add all .sh files at top level of the repo
-SH_FILES += [ FGristFiles [ ListFiles $(TOP) : *.sh ] ] ;
+SH_FILES += [ lffGlob $(SUBDIR) : *.sh ] ;
+
+# Manually specify all the bash files from the bin/ directory with no .sh file extension.
+# If a new such file is created in the bin/ directory, it should be manually added to this list.
+# (This list was originally built by running `shfmt -f ./bin` and removing entries with the '.sh' extension)
+SH_FILES_NO_EXTENSION = bin/7z-fromzip
+bin/7z-pack-arch
+bin/7z-pack-dir
+bin/7z-unpack-arch
+bin/curl-find-final-url
+bin/curl-timed
+bin/emacs-filecache-cleanup
+bin/genuuid
+bin/ham
+bin/ham-brew
+bin/ham-brew-fixup
+bin/ham-brew-install
+bin/ham-brew-installdir
+bin/ham-check-file
+bin/ham-clang-format
+bin/ham-clang-format-cpp
+bin/ham-cppm-bin-filepath
+bin/ham-cppm-build
+bin/ham-cppm-build-check
+bin/ham-cppm-exe-path
+bin/ham-cppm-get-toolset
+bin/ham-cppm-run
+bin/ham-dl-file
+bin/ham-editor
+bin/ham-env
+bin/ham-env-clear
+bin/ham-exec-retry
+bin/ham-find-dir-up
+bin/ham-find-file-up
+bin/ham-fix
+bin/ham-flymake
+bin/ham-gdb
+bin/ham-gen-compile-commands
+bin/ham-glob-files
+bin/ham-grep
+bin/ham-grep-for-emacs
+bin/ham-gt
+bin/ham-install-os-packages
+bin/ham-lint
+bin/ham-lint-fix
+bin/ham-ls-targets
+bin/ham-pm2
+bin/ham-rtcpp
+bin/ham-rtcpp-clean
+bin/ham-run-up
+bin/ham-ssh
+bin/ham-ssh-ls
+bin/ham-toolset
+bin/ham-toolset-build
+bin/ham-unpack
+bin/hamx
+bin/hash_md5
+bin/hat
+bin/lin-x64/lin-apt-install-nodeps
+bin/lin-x64/lin-listening
+bin/lin-x64/node
+bin/ls-dir-tree
+bin/ls-file-tree
+bin/mc-wrapper
+bin/ni
+bin/niui
+bin/niw
+bin/nt-x86/emacs
+bin/nt-x86/fzf
+bin/nt-x86/node
+bin/nt-x86/python3
+bin/osx/macos-listening
+bin/osx/macos-remove-from-quarantine
+bin/osx/macos-wake-reason
+bin/osx/macos-what-prevents-sleep
+bin/print-256-colours
+bin/run-for-xargs
+bin/simple-http-server
+bin/where_inpath ;
+SH_FILES += [ FGristFiles $(SH_FILES_NO_EXTENSION) ] ;
+
 # ECHO "... SH_FILES:" $(SH_FILES) ;
 
 lffFiles_sh lff_ham : $(SH_FILES) ;

--- a/_build.ham
+++ b/_build.ham
@@ -1,95 +1,12 @@
 SubDir TOP ;
 
-local BIN_DIR = [ FDirName $(SUBDIR) bin ] ;
-# ECHO "... BIN_DIR:" $(BIN_DIR) ;
-
-# Recursively get all .sh files inside of bin/ directory
-local SH_FILES = [ FGristFiles [ ListFilesR $(BIN_DIR) : *.sh ] ] ;
-
 # Add all .sh files at top level of the repo
 SH_FILES += [ lffGlob $(SUBDIR) : *.sh ] ;
-
-# Manually specify all the bash files from the bin/ directory with no .sh file extension.
-# If a new such file is created in the bin/ directory, it should be manually added to this list.
-# (This list was originally built by running `shfmt -f ./bin` and removing entries with the '.sh' extension)
-SH_FILES_NO_EXTENSION = bin/7z-fromzip
-bin/7z-pack-arch
-bin/7z-pack-dir
-bin/7z-unpack-arch
-bin/curl-find-final-url
-bin/curl-timed
-bin/emacs-filecache-cleanup
-bin/genuuid
-bin/ham
-bin/ham-brew
-bin/ham-brew-fixup
-bin/ham-brew-install
-bin/ham-brew-installdir
-bin/ham-check-file
-bin/ham-clang-format
-bin/ham-clang-format-cpp
-bin/ham-cppm-bin-filepath
-bin/ham-cppm-build
-bin/ham-cppm-build-check
-bin/ham-cppm-exe-path
-bin/ham-cppm-get-toolset
-bin/ham-cppm-run
-bin/ham-dl-file
-bin/ham-editor
-bin/ham-env
-bin/ham-env-clear
-bin/ham-exec-retry
-bin/ham-find-dir-up
-bin/ham-find-file-up
-bin/ham-fix
-bin/ham-flymake
-bin/ham-gdb
-bin/ham-gen-compile-commands
-bin/ham-glob-files
-bin/ham-grep
-bin/ham-grep-for-emacs
-bin/ham-gt
-bin/ham-install-os-packages
-bin/ham-lint
-bin/ham-lint-fix
-bin/ham-ls-targets
-bin/ham-pm2
-bin/ham-rtcpp
-bin/ham-rtcpp-clean
-bin/ham-run-up
-bin/ham-ssh
-bin/ham-ssh-ls
-bin/ham-toolset
-bin/ham-toolset-build
-bin/ham-unpack
-bin/hamx
-bin/hash_md5
-bin/hat
-bin/lin-x64/lin-apt-install-nodeps
-bin/lin-x64/lin-listening
-bin/lin-x64/node
-bin/ls-dir-tree
-bin/ls-file-tree
-bin/mc-wrapper
-bin/ni
-bin/niui
-bin/niw
-bin/nt-x86/emacs
-bin/nt-x86/fzf
-bin/nt-x86/node
-bin/nt-x86/python3
-bin/osx/macos-listening
-bin/osx/macos-remove-from-quarantine
-bin/osx/macos-wake-reason
-bin/osx/macos-what-prevents-sleep
-bin/print-256-colours
-bin/run-for-xargs
-bin/simple-http-server
-bin/where_inpath ;
-SH_FILES += [ FGristFiles $(SH_FILES_NO_EXTENSION) ] ;
 
 # ECHO "... SH_FILES:" $(SH_FILES) ;
 
 lffFiles_sh lff_ham : $(SH_FILES) ;
+
+SubInclude TOP bin ;
 
 SubInclude TOP sources ham tests ham-test-thrift ;

--- a/_build.ham
+++ b/_build.ham
@@ -1,0 +1,16 @@
+SubDir TOP ;
+
+local BIN_DIR = [ FDirName $(TOP) bin ] ;
+# ECHO "... BIN_DIR:" $(BIN_DIR) ;
+
+# Recursively get all .sh files inside of bin/ directory
+local SH_FILES = [ FGristFiles [ ListFilesR $(BIN_DIR) : *.sh ] ] ;
+# Add all files at top level of bin/ directory with no file suffix
+SH_FILES += [ FGristFiles [ Match (^[^.]*$) : [ ListFiles $(BIN_DIR) ] ] ] ;
+# Add all .sh files at top level of the repo
+SH_FILES += [ FGristFiles [ ListFiles $(TOP) : *.sh ] ] ;
+# ECHO "... SH_FILES:" $(SH_FILES) ;
+
+lffFiles_sh lff_ham : $(SH_FILES) ;
+
+SubInclude TOP sources ham tests ham-test-thrift ;

--- a/_env.sh
+++ b/_env.sh
@@ -3,14 +3,14 @@
 # This is a simple environment setup to start using ham:
 #   source ./ham/_env.sh
 #
-SCRIPT_SOURCED=$((return 0 2>/dev/null) && echo yes || echo "")
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-if [ -z "$SCRIPT_SOURCED" ]; then
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   echo "W/Should only be used while sourced."
 fi
 
 export HAM_HOME="$SCRIPT_DIR"
-export WORK="$( cd "$SCRIPT_DIR/.." && pwd )"
+WORK="$(cd "$SCRIPT_DIR/.." && pwd)"
+export WORK
 
 #
 # You dont want BASH_START_PATH since it will leak your local machine's
@@ -23,7 +23,7 @@ export WORK="$( cd "$SCRIPT_DIR/.." && pwd )"
 # fi
 
 if [ -z "$EDITOR" ]; then
-    export EDITOR=ham-editor
+  export EDITOR=ham-editor
 fi
 
 # Set the ham environment

--- a/_rules.ham
+++ b/_rules.ham
@@ -1,0 +1,9 @@
+#----------------------------------------------------------------------
+#     Toolkit definition
+#----------------------------------------------------------------------
+TK_NAME = "ham" ;
+TK_DIR = [ FGetAbsolutePath [ FDirName $(TOP) ] ] ;
+TOP_DIR = [ FDirName $(TK_DIR) ] ;
+TK_NONCE = 1 ;
+
+Import toolkit.ham ;

--- a/_run_ci.sh
+++ b/_run_ci.sh
@@ -3,31 +3,41 @@ echo "I/Setup ham environment"
 . hat repos default
 
 echo "I/Build ham"
-(set -x;
- cd "$HAM_HOME/sources/ham" ;
- ./build-${HAM_BIN_LOA}.sh)
+(
+  set -x
+  cd "$HAM_HOME/sources/ham"
+  ./build-"${HAM_BIN_LOA}".sh
+)
 
 echo "I/Run ham tests"
-(set -x;
- cd "$HAM_HOME/sources/ham/tests/ham_base" ;
- ham all)
+(
+  set -x
+  cd "$HAM_HOME/sources/ham/tests/ham_base"
+  ham all
+)
 
 echo "I/Build and run pi with ham"
-(set -x;
- ham -X ham/sources/ham/tests/pi Run_pi)
+(
+  set -x
+  ham -X ham/sources/ham/tests/pi Run_pi
+)
 
 echo "I/Test examples"
-(set -x;
- ham -X ham/sources/examples/py3-venv-web-scrape _run_ci.sh)
+(
+  set -x
+  ham -X ham/sources/examples/py3-venv-web-scrape _run_ci.sh
+)
 
 echo "I/Build cppm modules."
 case $HAM_OS in
-    NT*|OSX*|LINUX*)
-        (set -x ;
-         "$HAM_HOME/sources/ham/tests/ham-test-thrift/_run_ci.sh")
-        ;;
-    *)
-        echo "E/Toolset: Unsupported host OS"
-        return 1
-        ;;
+  NT* | OSX* | LINUX*)
+    (
+      set -x
+      "$HAM_HOME/sources/ham/tests/ham-test-thrift/_run_ci.sh"
+    )
+    ;;
+  *)
+    echo "E/Toolset: Unsupported host OS"
+    return 1
+    ;;
 esac

--- a/bin/_build.ham
+++ b/bin/_build.ham
@@ -1,0 +1,87 @@
+if [ SubDirOnce TOP bin ] = 1 { return ; }
+
+# Recursively get all .sh files
+local SH_FILES = [ FGristFiles [ ListFilesR $(SUBDIR) : *.sh ] ] ;
+
+# Manually specify all the bash files with no .sh file extension.
+# If a new such file is created, it should be manually added to this list.
+# (This list was originally built by running `shfmt -f .` and removing entries with the '.sh' extension)
+SH_FILES_NO_EXTENSION = 7z-fromzip
+7z-pack-arch
+7z-pack-dir
+7z-unpack-arch
+curl-find-final-url
+curl-timed
+emacs-filecache-cleanup
+genuuid
+ham
+ham-brew
+ham-brew-fixup
+ham-brew-install
+ham-brew-installdir
+ham-check-file
+ham-clang-format
+ham-clang-format-cpp
+ham-cppm-bin-filepath
+ham-cppm-build
+ham-cppm-build-check
+ham-cppm-exe-path
+ham-cppm-get-toolset
+ham-cppm-run
+ham-dl-file
+ham-editor
+ham-env
+ham-env-clear
+ham-exec-retry
+ham-find-dir-up
+ham-find-file-up
+ham-fix
+ham-flymake
+ham-gdb
+ham-gen-compile-commands
+ham-glob-files
+ham-grep
+ham-grep-for-emacs
+ham-gt
+ham-install-os-packages
+ham-lint
+ham-lint-fix
+ham-ls-targets
+ham-pm2
+ham-rtcpp
+ham-rtcpp-clean
+ham-run-up
+ham-ssh
+ham-ssh-ls
+ham-toolset
+ham-toolset-build
+ham-unpack
+hamx
+hash_md5
+hat
+lin-x64/lin-apt-install-nodeps
+lin-x64/lin-listening
+lin-x64/node
+ls-dir-tree
+ls-file-tree
+mc-wrapper
+ni
+niui
+niw
+nt-x86/emacs
+nt-x86/fzf
+nt-x86/node
+nt-x86/python3
+osx/macos-listening
+osx/macos-remove-from-quarantine
+osx/macos-wake-reason
+osx/macos-what-prevents-sleep
+print-256-colours
+run-for-xargs
+simple-http-server
+where_inpath ;
+SH_FILES += [ FGristFiles $(SUBDIR)/$(SH_FILES_NO_EXTENSION) ] ;
+
+# ECHO "... bin/ SH_FILES:" $(SH_FILES) ;
+
+lffFiles_sh lff_ham-bin : $(SH_FILES) ;

--- a/sources/ham/tests/ham-test-thrift/_build.ham
+++ b/sources/ham/tests/ham-test-thrift/_build.ham
@@ -1,11 +1,6 @@
-MODULE_NAME = ham-test-thrift ;
-if [ SubDirOnce TOP sources ham tests $(MODULE_NAME) ] = 1 { return ; }
-# SubDir TOP ;
+if [ SubDirOnce TOP sources ham tests ham-test-thrift ] = 1 { return ; }
 
-# local DIR = [ FDirName $(TOP) $(SUBDIR) ] ;
-local DIR = [ FDirName $(SUBDIR) ] ;
-# ECHO "... DIR:" $(DIR) ;
-local SH_FILES = [ lffGlob $(DIR) : .sh ] ;
+local SH_FILES = [ lffGlob $(SUBDIR) : .sh ] ;
 # ECHO "... SH_FILES:" $(SH_FILES) ;
 lffFiles_sh lff_ham-test-thrift : $(SH_FILES) ;
 

--- a/sources/ham/tests/ham-test-thrift/_build.ham
+++ b/sources/ham/tests/ham-test-thrift/_build.ham
@@ -1,12 +1,15 @@
-SubDir TOP ;
+MODULE_NAME = ham-test-thrift ;
+if [ SubDirOnce TOP sources ham tests $(MODULE_NAME) ] = 1 { return ; }
+# SubDir TOP ;
 
-local DIR = [ FDirName $(TOP) $(SUBDIR) ] ;
+# local DIR = [ FDirName $(TOP) $(SUBDIR) ] ;
+local DIR = [ FDirName $(SUBDIR) ] ;
 # ECHO "... DIR:" $(DIR) ;
 local SH_FILES = [ lffGlob $(DIR) : .sh ] ;
 # ECHO "... SH_FILES:" $(SH_FILES) ;
 lffFiles_sh lff_ham-test-thrift : $(SH_FILES) ;
 
 if $(TARGET_FEATURE_CONSOLE) {
-  SubInclude TOP src_client ;
-  SubInclude TOP src_server ;
+  SubInclude TOP sources ham tests ham-test-thrift src_client ;
+  SubInclude TOP sources ham tests ham-test-thrift src_server ;
 }

--- a/sources/ham/tests/ham-test-thrift/src_client/_build.ham
+++ b/sources/ham/tests/ham-test-thrift/src_client/_build.ham
@@ -1,4 +1,5 @@
-if [ SubDirOnce TOP src_client ] = 1 { return ; }
+MODULE_NAME = ham-test-thrift ;
+if [ SubDirOnce TOP sources ham tests $(MODULE_NAME) src_client ] = 1 { return ; }
 
 tkDefTool ham-test-thrift-client : 1.0.0 ;
 hamToolsetHdrs boost_cppm : ham ;

--- a/sources/ham/tests/ham-test-thrift/src_client/_build.ham
+++ b/sources/ham/tests/ham-test-thrift/src_client/_build.ham
@@ -1,5 +1,4 @@
-MODULE_NAME = ham-test-thrift ;
-if [ SubDirOnce TOP sources ham tests $(MODULE_NAME) src_client ] = 1 { return ; }
+if [ SubDirOnce TOP sources ham tests ham-test-thrift src_client ] = 1 { return ; }
 
 tkDefTool ham-test-thrift-client : 1.0.0 ;
 hamToolsetHdrs boost_cppm : ham ;

--- a/sources/ham/tests/ham-test-thrift/src_server/_build.ham
+++ b/sources/ham/tests/ham-test-thrift/src_server/_build.ham
@@ -1,5 +1,4 @@
-MODULE_NAME = ham-test-thrift ;
-if [ SubDirOnce TOP sources ham tests $(MODULE_NAME) src_server ] = 1 { return ; }
+if [ SubDirOnce TOP sources ham tests ham-test-thrift src_server ] = 1 { return ; }
 
 tkDefTool ham-test-thrift-server : 1.0.0 ;
 hamToolsetHdrs boost_cppm : ham ;

--- a/sources/ham/tests/ham-test-thrift/src_server/_build.ham
+++ b/sources/ham/tests/ham-test-thrift/src_server/_build.ham
@@ -1,4 +1,5 @@
-if [ SubDirOnce TOP src_server ] = 1 { return ; }
+MODULE_NAME = ham-test-thrift ;
+if [ SubDirOnce TOP sources ham tests $(MODULE_NAME) src_server ] = 1 { return ; }
 
 tkDefTool ham-test-thrift-server : 1.0.0 ;
 hamToolsetHdrs boost_cppm : ham ;


### PR DESCRIPTION
<!---
- Provide a general summary of your changes in the Title above.
- Include your username with the main subject of your change.
- Use the imperative mood, steering clear of gerunds (verbs acting as nouns, usually ending in 'ing') and past tense in the title. Focus on the result, not your actions.
- Example: "Squirrel: module-name: Add the recipe for nuts racoon foie-gras."
- NOTE: Use the same imperative mood for commit messages & formal notes.
-->

## Formal Notes
<!---
- Release notes (RN) should be considered PUBLIC and go into the project's public release notes. Other notes are internal.
- NOTE: Do NOT mention private/internal info in public release notes.
- Use the imperative mood, steering clear of gerunds and past tense in the notes. Focus on the result, not your actions.
- Example of a public note: "RN: module-name: Add support for FooFeature."
- Example of an internal note: "NoRN: module-name: Improve or fix FooThing."
- All entries must use RN or NoRN.
-->

* RN: ham: Add bash script linting to the top level of the ham repo ;
* RN: Fix lint and format issues in top-level `_env.sh` and `_run_ci.sh` scripts ;

## Description, Motivation and Context
<!---
- A more detailed description of what's going on.
- Why is this change required? What problem does it solve?
- Link to related issues/PRs: Fixes #0000 / WiP #0000 / Closes #0000
-->

I created a new `_build.ham` and `_rules.ham` in the root of the repo, and changed the `ham-test-thrift` to now be a subdir of the root. It's very likely I have not configured some part of this correctly, as I am not clear on how the subdir stuff works and tried to figure it out by looking at the `_build.ham` structure of the reddoor repo.

I am at least seeing the following behavior which is working as I would expect:
- Running `ham lint` in the root `ham/` directory will lint all the root-level bash scripts as well as all of the bash scripts in the `ham-test-thrift` subproject.
- Running `ham lint` from within the `ham-test-thrift` directory will only lint the bash scripts configured in this subproject's `_build.ham` file.

## How Has This Been Tested?
<!---
- Please describe in detail how you tested your changes.
- Include *full* CLI commands
- Include details of your testing environment, and the tests you ran to
- see how your change affects other areas of the code, etc.
-->

Command line to run all the tests that I run locally:
```bash
# Lint only
ham lint
# Fix only
ham fix
# Fix and Lint together
ham lff
```

<!---
## Checklist:
* What I did is actually needed (I have a link to an issue and/or a meeting note/wiki doc to prove it)
* I have assigned appropriate labels and projects.
* My code is stylish, commented, and in the right place.
* I have added tests to cover my changes.
* All new and existing tests passed.
* I have updated the documentation appropriately.
-->

## Types Of Changes
<!---
- What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that causes existing functionality to change)
* [ ] Documentation (code docs, comments, or changes to the doc systems)
* [ ] Testing/Build (test coverage or the test/build subsystems themselves)
* [ ] Packaging (adds examples or modifies a release package)

<!---
- This template is stored in .github/PULL_REQUEST_TEMPLATE.md
-->
