### PR TITLE
Various: os package manager utility bash functions, various ham rules improvements, ham make is less forgiving.

### DIFF
--- a/_run_ci.sh
+++ b/_run_ci.sh
@@ -1,6 +1,12 @@
 #!/bin/bash -e
 . hat repos default shell_linter
 
+log_info "The ham-bash-lib.sh"
+(
+  set -x
+  bash "$HAM_HOME/bin/ham-bash-lib-tests.sh"
+)
+
 log_info "Build ham"
 (
   set -x

--- a/bin/ham-bash-lib-tests.sh
+++ b/bin/ham-bash-lib-tests.sh
@@ -188,31 +188,23 @@ test_brew_package_manager() {
 #######################################################################
 # Run package manager tests based on detection
 #######################################################################
-detect_package_manager() {
-  command -v "$1" &>/dev/null
-  return $?
-}
-
-if detect_package_manager "pacman"; then
-  log_info "pacman detected, adding tests for it"
-  test_pacman_package_manager
-else
-  log_warning "pacman not found, not adding its tests"
-fi
-
-if detect_package_manager "apt-get"; then
-  log_info "apt-get detected, adding tests for it"
-  test_apt_package_manager
-else
-  log_warning "apt-get not found, not adding its tests"
-fi
-
-if detect_package_manager "brew"; then
-  log_info "brew detected, adding tests for it"
-  test_brew_package_manager
-else
-  log_warning "brew not found, not adding its tests"
-fi
+log_info "Adding tests for the detected package manager '$DETECTED_PACKAGE_MANAGER'."
+case "$DETECTED_PACKAGE_MANAGER" in
+  pacman)
+    test_pacman_package_manager
+    ;;
+  apt)
+    test_apt_package_manager
+    ;;
+  brew)
+    test_brew_package_manager
+    ;;
+  none) ;;
+  *)
+    log_error "Unexpected detected package manager: '$DETECTED_PACKAGE_MANAGER'."
+    exit 1
+    ;;
+esac
 
 ###########################################################################
 # TESTS: ham_os_package_syslib

--- a/bin/ham-bash-lib-tests.sh
+++ b/bin/ham-bash-lib-tests.sh
@@ -286,7 +286,7 @@ else
     value=$(ham_os_package_syslib_check_and_install "include" "wee_iamnotapackage.h" apt:wee_iamnotapackage-bla wee_iamnotapackage 2>&1)
     CHECK_EQUAL 1 $? "call should fail" || return 1
     log_info "... value: $value"
-    CHECK_CONTAINS "ham_os_package_syslib_check_and_install: Unable to find 'wee_iamnotapackage.h' after installing package 'wee_iamnotapackage'" "$value" "curl/curl.h should be found after check/install" || return 1
+    CHECK_CONTAINS "ham_os_package_syslib_check_and_install: Unable to find 'wee_iamnotapackage.h' after installing package" "$value" "Should tell us that it cant find the non existant header." || return 1
   }
   TEST "ham_os_package_syslib" "test__ham_os_package_syslib_check_and_install__non_existent_package"
 fi

--- a/bin/ham-bash-lib-tests.sh
+++ b/bin/ham-bash-lib-tests.sh
@@ -1,0 +1,300 @@
+#!/bin/bash
+#
+# run:
+#   bash "$HAM_HOME/bin/ham-bash-lib-tests.sh"
+#
+if [[ -z "$HAM_HOME" ]]; then
+  echo "E/HAM_HOME not set !"
+  exit 1
+fi
+. "$HAM_HOME/bin/ham-bash-lib.sh"
+. "$HAM_HOME/bin/ham-bash-lib-unittest.sh"
+
+log_info "HAM_OS_PACKAGE_MANAGER: ${HAM_OS_PACKAGE_MANAGER}"
+
+###########################################################################
+# TESTS: ham_os_package
+###########################################################################
+FIXTURE "ham_os_package"
+
+DETECTED_PACKAGE_MANAGER=$(ham_os_package_detect_default_manager)
+log_info "DETECTED_PACKAGE_MANAGER: ${DETECTED_PACKAGE_MANAGER}"
+
+# shellcheck disable=SC2317
+test__ham_os_package__default_package_manager() {
+  local FUNC=test__ham_os_package__default_package_manager
+  case "$HAM_OS" in
+    NT*)
+      CHECK_EQUAL "none" "$DETECTED_PACKAGE_MANAGER" "Windows package manager should be none."
+      ;;
+    LINUX*)
+      if has_inpath pacman; then
+        CHECK_EQUAL "pacman" "$DETECTED_PACKAGE_MANAGER" "Arch/SteamOS package manager should be pacman."
+      else
+        CHECK_EQUAL "apt" "$DETECTED_PACKAGE_MANAGER" "Ubuntu/Debian package manager should be apt."
+      fi
+      ;;
+    OSX*)
+      CHECK_EQUAL "brew" "$DETECTED_PACKAGE_MANAGER" "macOS package manager should be brew."
+      ;;
+    *)
+      complain "$FUNC" "Unknown HAM_OS: $HAM_OS"
+      return 1
+      ;;
+  esac
+
+  CHECK_NOT_EQUAL "" "$HAM_OS_PACKAGE_MANAGER" "HAM_OS_PACKAGE_MANAGER shouldn't be empty"
+}
+TEST "ham_os_package" "test__ham_os_package__default_package_manager"
+
+# shellcheck disable=SC2317
+test__ham_os_package__find_in_usr_dir() {
+  local value
+  value=$(ham_os_package_find_in_usr_dir include "curl/curl.h")
+  log_info "value: $value"
+  CHECK_CONTAINS "curl/curl.h" "$value" "curl/curl.h should exist"
+}
+TEST "ham_os_package" "test__ham_os_package__find_in_usr_dir"
+
+###########################################################################
+# TESTS: ham_os_package_get_value_tests
+###########################################################################
+FIXTURE "ham_os_package_get_value_tests"
+
+# shellcheck disable=SC2317
+test_matching_key_apt() {
+  CHECK_EQUAL "binutils-dev" "$(ham_os_package_get_value "apt" "apt:binutils-dev" "pacman:binutils" "brew:binutils" "default_value")"
+}
+TEST "ham_os_package_get_value_tests" "test_matching_key_apt"
+
+# shellcheck disable=SC2317
+test_matching_key_pacman() {
+  CHECK_EQUAL "binutils" "$(ham_os_package_get_value "pacman" "apt:binutils-dev" "pacman:binutils" "brew:binutils" "default_value")"
+}
+TEST "ham_os_package_get_value_tests" "test_matching_key_pacman"
+
+# shellcheck disable=SC2317
+test_fallback_to_default_value() {
+  CHECK_EQUAL "default_value" "$(ham_os_package_get_value "unknown" "apt:binutils-dev" "pacman:binutils" "brew:binutils" "default_value")"
+}
+TEST "ham_os_package_get_value_tests" "test_fallback_to_default_value"
+
+# shellcheck disable=SC2317
+test_error_multiple_default_values() {
+  # NOTE: we cannot use local here because it'll eat the return code
+  value=$(ham_os_package_get_value "apt" "apt:binutils-dev" "pacman:binutils" "brew:binutils" "default_value" "another_default" 2>&1)
+  CHECK_EQUAL 1 $? "Expecting an error, exit code should be 1."
+  CHECK_CONTAINS "ham_os_package_get_value: Multiple default values specified." "$value"
+}
+TEST "ham_os_package_get_value_tests" "test_error_multiple_default_values"
+
+# shellcheck disable=SC2317
+test_error_no_match_no_default() {
+  ham_os_package_get_value "unknown" "apt:binutils-dev" "pacman:binutils" "brew:binutils"
+  CHECK_EQUAL 1 $? "Expecting an error, exit code should be 1."
+}
+TEST "ham_os_package_get_value_tests" "test_error_no_match_no_default"
+
+#######################################################################
+# TESTS: pacman package manager tests
+#######################################################################
+
+test_pacman_package_manager() {
+  FIXTURE "pacman_package_tests"
+
+  # shellcheck disable=SC2317
+  test_pacman_curl_exists() {
+    ham_os_package_exist_pacman "curl"
+    CHECK_EQUAL 0 $? "pacman: curl should exist"
+  }
+  TEST "pacman_package_tests" "test_pacman_curl_exists"
+
+  # shellcheck disable=SC2317
+  test_pacman_non_existent_package() {
+    ham_os_package_exist_pacman "wee_iamnotapackage"
+    CHECK_EQUAL 1 $? "$()" "pacman: wee_iamnotapackage should not exist"
+  }
+  TEST "pacman_package_tests" "test_pacman_non_existent_package"
+
+  # shellcheck disable=SC2317
+  test_pacman_curl_already_installed() {
+    value=$(ham_os_package_check_and_install_pacman "curl")
+    CHECK_EQUAL 0 $? "Already packaged installed should return a success code."
+    CHECK_CONTAINS "Package 'curl' is already installed." "$value"
+  }
+  TEST "pacman_package_tests" "test_pacman_curl_already_installed"
+}
+
+#######################################################################
+# TESTS: apt package manager tests
+#######################################################################
+test_apt_package_manager() {
+  FIXTURE "apt_package_tests"
+
+  # shellcheck disable=SC2317
+  test_apt_curl_exists() {
+    ham_os_package_exist_apt "curl"
+    CHECK_EQUAL 0 $? "apt: curl should exist"
+  }
+  TEST "apt_package_tests" "test_apt_curl_exists"
+
+  # shellcheck disable=SC2317
+  test_apt_non_existent_package() {
+    ham_os_package_exist_apt "wee_iamnotapackage"
+    CHECK_EQUAL 1 $? "$()" "apt: wee_iamnotapackage should not exist"
+  }
+  TEST "apt_package_tests" "test_apt_non_existent_package"
+
+  # shellcheck disable=SC2317
+  test_apt_curl_already_installed() {
+    value=$(ham_os_package_check_and_install_apt "curl")
+    CHECK_EQUAL 0 $? "Already packaged installed should return a success code."
+    CHECK_CONTAINS "Package 'curl' is already installed." "$value"
+  }
+  TEST "apt_package_tests" "test_apt_curl_already_installed"
+}
+
+#######################################################################
+# TESTS: brew package manager tests
+#######################################################################
+test_brew_package_manager() {
+  FIXTURE "brew_package_tests"
+
+  # shellcheck disable=SC2317
+  test_brew_curl_exists() {
+    ham_os_package_exist_brew "curl"
+    CHECK_EQUAL 0 $? "brew: curl should exist"
+  }
+  TEST "brew_package_tests" "test_brew_curl_exists"
+
+  # shellcheck disable=SC2317
+  test_brew_non_existent_package() {
+    ham_os_package_exist_brew "wee_iamnotapackage"
+    CHECK_EQUAL 1 $? "$()" "brew: wee_iamnotapackage should not exist"
+  }
+  TEST "brew_package_tests" "test_brew_non_existent_package"
+
+  # shellcheck disable=SC2317
+  test_brew_curl_already_installed() {
+    value=$(ham_os_package_check_and_install_brew "curl")
+    CHECK_EQUAL 0 $? "Already packaged installed should return a success code."
+    CHECK_CONTAINS "Package 'curl' is already installed." "$value"
+  }
+  TEST "brew_package_tests" "test_brew_curl_already_installed"
+}
+
+#######################################################################
+# Run package manager tests based on detection
+#######################################################################
+detect_package_manager() {
+  command -v "$1" &>/dev/null
+  return $?
+}
+
+if detect_package_manager "pacman"; then
+  log_info "pacman detected, adding tests for it"
+  test_pacman_package_manager
+else
+  log_warning "pacman not found, not adding its tests"
+fi
+
+if detect_package_manager "apt-get"; then
+  log_info "apt-get detected, adding tests for it"
+  test_apt_package_manager
+else
+  log_warning "apt-get not found, not adding its tests"
+fi
+
+if detect_package_manager "brew"; then
+  log_info "brew detected, adding tests for it"
+  test_brew_package_manager
+else
+  log_warning "brew not found, not adding its tests"
+fi
+
+###########################################################################
+# TESTS: ham_os_package_syslib
+###########################################################################
+FIXTURE "ham_os_package_syslib"
+
+if [[ "$HAM_OS_PACKAGE_MANAGER" == "none" ]]; then
+  # shellcheck disable=SC2317
+  test__ham_os_package_syslib_no_package_manager() {
+    CHECK_EQUAL "NT" "$HAM_OS" "Only Windows doesnt have a package manager atm, got '$HAM_OS'."
+  }
+  TEST "ham_os_package_syslib" "test__ham_os_package_syslib_no_package_manager"
+
+else
+  # shellcheck disable=SC2317
+  test__ham_os_package_syslib_find_file__curl_include() {
+    local FUNC=test__ham_os_package_syslib_find_file__curl_include
+    value=$(ham_os_package_syslib_find_file "include" "curl/curl.h" apt:libcurl4-openssl-dev pacman:curl brew:curl)
+    CHECK_EQUAL 0 $? "call should succeed"
+    log_info "... value: $value"
+    CHECK_CONTAINS "curl/curl.h" "$value" "curl/curl.h should exist in the include path"
+  }
+  TEST "ham_os_package_syslib" "test__ham_os_package_syslib_find_file__curl_include"
+
+  # shellcheck disable=SC2317
+  test__ham_os_package_syslib_find_file__curl_lib() {
+    local FUNC=test__ham_os_package_syslib_find_file__curl_lib
+    value=$(ham_os_package_syslib_find_file "lib" "libcurl.so" apt:libcurl4-openssl-dev curl)
+    CHECK_EQUAL 0 $? "call should succeed"
+    log_info "... value: $value"
+    CHECK_CONTAINS "libcurl.so" "$value" "libcurl.so should exist in the lib path"
+  }
+  TEST "ham_os_package_syslib" "test__ham_os_package_syslib_find_file__curl_lib"
+
+  # shellcheck disable=SC2317
+  test__ham_os_package_syslib_check_and_install__curl_include() {
+    local FUNC=test__ham_os_package_syslib_check_and_install__curl_include
+    value=$(ham_os_package_syslib_check_and_install "include" "curl/curl.h" apt:libcurl4-openssl-dev pacman:curl brew:curl)
+    CHECK_EQUAL 0 $? "call should succeed"
+    log_info "... value: $value"
+    CHECK_CONTAINS "curl/curl.h" "$value" "curl/curl.h should be found after check/install"
+  }
+  TEST "ham_os_package_syslib" "test__ham_os_package_syslib_check_and_install__curl_include"
+
+  # shellcheck disable=SC2317
+  test__ham_os_package_syslib_check_and_install__autossh_bin() {
+    case "$HAM_OS_PACKAGE_MANAGER" in
+      pacman)
+        log_info "Uninstalling autossh to test reinstall..."
+        (
+          set -ex
+          sudo pacman -R --noconfirm autossh
+        )
+        ;;
+      *)
+        log_warning "Don't know how to uninstall autossh."
+        ;;
+    esac
+    CHECK_EQUAL 0 $? "uninstall of autossh should succeed"
+
+    local FUNC=test__ham_os_package_syslib_check_and_install__autossh_bin
+    value=$(ham_os_package_syslib_check_and_install "bin" "autossh" autossh)
+    CHECK_EQUAL 0 $? "install of autossh should succeed"
+    log_info "... value: $value"
+    expected_path=$(ham_os_package_syslib_find_file "bin" "autossh" autossh)
+    log_info "... expected_path: $expected_path"
+    CHECK_CONTAINS "autossh" "$value" "check_and_install output should at least contain autossh"
+    CHECK_EQUAL "$expected_path" "$value" "check_and_install should be consistent with ham_os_package_syslib_find_file"
+  }
+  TEST "ham_os_package_syslib" "test__ham_os_package_syslib_check_and_install__autossh_bin"
+
+  # shellcheck disable=SC2317
+  test__ham_os_package_syslib_check_and_install__non_existent_package() {
+    local FUNC=test__ham_os_package_syslib_check_and_install__non_existent_package
+    value=$(ham_os_package_syslib_check_and_install "include" "wee_iamnotapackage.h" apt:wee_iamnotapackage-bla wee_iamnotapackage 2>&1)
+    CHECK_EQUAL 1 $? "call should fail"
+    log_info "... value: $value"
+    CHECK_CONTAINS "ham_os_package_syslib_check_and_install: Unable to find 'wee_iamnotapackage.h' after installing package 'wee_iamnotapackage'" "$value" "curl/curl.h should be found after check/install"
+  }
+  TEST "ham_os_package_syslib" "test__ham_os_package_syslib_check_and_install__non_existent_package"
+fi
+
+###########################################################################
+# RUN_TESTS
+###########################################################################
+RUN_TESTS "$1"
+exit $?

--- a/bin/ham-bash-lib-tests.sh
+++ b/bin/ham-bash-lib-tests.sh
@@ -25,17 +25,17 @@ test__ham_os_package__default_package_manager() {
   local FUNC=test__ham_os_package__default_package_manager
   case "$HAM_OS" in
     NT*)
-      CHECK_EQUAL "none" "$DETECTED_PACKAGE_MANAGER" "Windows package manager should be none."
+      CHECK_EQUAL "none" "$DETECTED_PACKAGE_MANAGER" "Windows package manager should be none." || return 1
       ;;
     LINUX*)
       if has_inpath pacman; then
-        CHECK_EQUAL "pacman" "$DETECTED_PACKAGE_MANAGER" "Arch/SteamOS package manager should be pacman."
+        CHECK_EQUAL "pacman" "$DETECTED_PACKAGE_MANAGER" "Arch/SteamOS package manager should be pacman." || return 1
       else
-        CHECK_EQUAL "apt" "$DETECTED_PACKAGE_MANAGER" "Ubuntu/Debian package manager should be apt."
+        CHECK_EQUAL "apt" "$DETECTED_PACKAGE_MANAGER" "Ubuntu/Debian package manager should be apt." || return 1
       fi
       ;;
     OSX*)
-      CHECK_EQUAL "brew" "$DETECTED_PACKAGE_MANAGER" "macOS package manager should be brew."
+      CHECK_EQUAL "brew" "$DETECTED_PACKAGE_MANAGER" "macOS package manager should be brew." || return 1
       ;;
     *)
       complain "$FUNC" "Unknown HAM_OS: $HAM_OS"
@@ -43,18 +43,20 @@ test__ham_os_package__default_package_manager() {
       ;;
   esac
 
-  CHECK_NOT_EQUAL "" "$HAM_OS_PACKAGE_MANAGER" "HAM_OS_PACKAGE_MANAGER shouldn't be empty"
+  CHECK_NOT_EQUAL "" "$HAM_OS_PACKAGE_MANAGER" "HAM_OS_PACKAGE_MANAGER shouldn't be empty" || return 1
 }
 TEST "ham_os_package" "test__ham_os_package__default_package_manager"
 
-# shellcheck disable=SC2317
-test__ham_os_package__find_in_usr_dir() {
-  local value
-  value=$(ham_os_package_find_in_usr_dir include "curl/curl.h")
-  log_info "value: $value"
-  CHECK_CONTAINS "curl/curl.h" "$value" "curl/curl.h should exist"
-}
-TEST "ham_os_package" "test__ham_os_package__find_in_usr_dir"
+if [[ "$HAM_OS_PACKAGE_MANAGER" != "none" && "$HAM_OS_PACKAGE_MANAGER" != "brew" ]]; then
+  # shellcheck disable=SC2317
+  test__ham_os_package__find_in_usr_dir() {
+    local value
+    value=$(ham_os_package_find_in_usr_dir include "curl/curl.h")
+    log_info "value: $value"
+    CHECK_CONTAINS "curl/curl.h" "$value" "curl/curl.h should exist" || return 1
+  }
+  TEST "ham_os_package" "test__ham_os_package__find_in_usr_dir"
+fi
 
 ###########################################################################
 # TESTS: ham_os_package_get_value_tests
@@ -63,19 +65,19 @@ FIXTURE "ham_os_package_get_value_tests"
 
 # shellcheck disable=SC2317
 test_matching_key_apt() {
-  CHECK_EQUAL "binutils-dev" "$(ham_os_package_get_value "apt" "apt:binutils-dev" "pacman:binutils" "brew:binutils" "default_value")"
+  CHECK_EQUAL "binutils-dev" "$(ham_os_package_get_value "apt" "apt:binutils-dev" "pacman:binutils" "brew:binutils" "default_value")" || return 1
 }
 TEST "ham_os_package_get_value_tests" "test_matching_key_apt"
 
 # shellcheck disable=SC2317
 test_matching_key_pacman() {
-  CHECK_EQUAL "binutils" "$(ham_os_package_get_value "pacman" "apt:binutils-dev" "pacman:binutils" "brew:binutils" "default_value")"
+  CHECK_EQUAL "binutils" "$(ham_os_package_get_value "pacman" "apt:binutils-dev" "pacman:binutils" "brew:binutils" "default_value")" || return 1
 }
 TEST "ham_os_package_get_value_tests" "test_matching_key_pacman"
 
 # shellcheck disable=SC2317
 test_fallback_to_default_value() {
-  CHECK_EQUAL "default_value" "$(ham_os_package_get_value "unknown" "apt:binutils-dev" "pacman:binutils" "brew:binutils" "default_value")"
+  CHECK_EQUAL "default_value" "$(ham_os_package_get_value "unknown" "apt:binutils-dev" "pacman:binutils" "brew:binutils" "default_value")" || return 1
 }
 TEST "ham_os_package_get_value_tests" "test_fallback_to_default_value"
 
@@ -83,15 +85,15 @@ TEST "ham_os_package_get_value_tests" "test_fallback_to_default_value"
 test_error_multiple_default_values() {
   # NOTE: we cannot use local here because it'll eat the return code
   value=$(ham_os_package_get_value "apt" "apt:binutils-dev" "pacman:binutils" "brew:binutils" "default_value" "another_default" 2>&1)
-  CHECK_EQUAL 1 $? "Expecting an error, exit code should be 1."
-  CHECK_CONTAINS "ham_os_package_get_value: Multiple default values specified." "$value"
+  CHECK_EQUAL 1 $? "Expecting an error, exit code should be 1." || return 1
+  CHECK_CONTAINS "ham_os_package_get_value: Multiple default values specified." "$value" || return 1
 }
 TEST "ham_os_package_get_value_tests" "test_error_multiple_default_values"
 
 # shellcheck disable=SC2317
 test_error_no_match_no_default() {
   ham_os_package_get_value "unknown" "apt:binutils-dev" "pacman:binutils" "brew:binutils"
-  CHECK_EQUAL 1 $? "Expecting an error, exit code should be 1."
+  CHECK_EQUAL 1 $? "Expecting an error, exit code should be 1." || return 1
 }
 TEST "ham_os_package_get_value_tests" "test_error_no_match_no_default"
 
@@ -105,22 +107,22 @@ test_pacman_package_manager() {
   # shellcheck disable=SC2317
   test_pacman_curl_exists() {
     ham_os_package_exist_pacman "curl"
-    CHECK_EQUAL 0 $? "pacman: curl should exist"
+    CHECK_EQUAL 0 $? "pacman: curl should exist" || return 1
   }
   TEST "pacman_package_tests" "test_pacman_curl_exists"
 
   # shellcheck disable=SC2317
   test_pacman_non_existent_package() {
     ham_os_package_exist_pacman "wee_iamnotapackage"
-    CHECK_EQUAL 1 $? "$()" "pacman: wee_iamnotapackage should not exist"
+    CHECK_EQUAL 1 $? "$()" "pacman: wee_iamnotapackage should not exist" || return 1
   }
   TEST "pacman_package_tests" "test_pacman_non_existent_package"
 
   # shellcheck disable=SC2317
   test_pacman_curl_already_installed() {
     value=$(ham_os_package_check_and_install_pacman "curl")
-    CHECK_EQUAL 0 $? "Already packaged installed should return a success code."
-    CHECK_CONTAINS "Package 'curl' is already installed." "$value"
+    CHECK_EQUAL 0 $? "Already packaged installed should return a success code." || return 1
+    CHECK_CONTAINS "Package 'curl' is already installed." "$value" || return 1
   }
   TEST "pacman_package_tests" "test_pacman_curl_already_installed"
 }
@@ -134,22 +136,22 @@ test_apt_package_manager() {
   # shellcheck disable=SC2317
   test_apt_curl_exists() {
     ham_os_package_exist_apt "curl"
-    CHECK_EQUAL 0 $? "apt: curl should exist"
+    CHECK_EQUAL 0 $? "apt: curl should exist" || return 1
   }
   TEST "apt_package_tests" "test_apt_curl_exists"
 
   # shellcheck disable=SC2317
   test_apt_non_existent_package() {
     ham_os_package_exist_apt "wee_iamnotapackage"
-    CHECK_EQUAL 1 $? "$()" "apt: wee_iamnotapackage should not exist"
+    CHECK_EQUAL 1 $? "$()" "apt: wee_iamnotapackage should not exist" || return 1
   }
   TEST "apt_package_tests" "test_apt_non_existent_package"
 
   # shellcheck disable=SC2317
   test_apt_curl_already_installed() {
     value=$(ham_os_package_check_and_install_apt "curl")
-    CHECK_EQUAL 0 $? "Already packaged installed should return a success code."
-    CHECK_CONTAINS "Package 'curl' is already installed." "$value"
+    CHECK_EQUAL 0 $? "Already packaged installed should return a success code." || return 1
+    CHECK_CONTAINS "Package 'curl' is already installed." "$value" || return 1
   }
   TEST "apt_package_tests" "test_apt_curl_already_installed"
 }
@@ -163,22 +165,22 @@ test_brew_package_manager() {
   # shellcheck disable=SC2317
   test_brew_curl_exists() {
     ham_os_package_exist_brew "curl"
-    CHECK_EQUAL 0 $? "brew: curl should exist"
+    CHECK_EQUAL 0 $? "brew: curl should exist" || return 1
   }
   TEST "brew_package_tests" "test_brew_curl_exists"
 
   # shellcheck disable=SC2317
   test_brew_non_existent_package() {
     ham_os_package_exist_brew "wee_iamnotapackage"
-    CHECK_EQUAL 1 $? "$()" "brew: wee_iamnotapackage should not exist"
+    CHECK_EQUAL 1 $? "$()" "brew: wee_iamnotapackage should not exist" || return 1
   }
   TEST "brew_package_tests" "test_brew_non_existent_package"
 
   # shellcheck disable=SC2317
   test_brew_curl_already_installed() {
     value=$(ham_os_package_check_and_install_brew "curl")
-    CHECK_EQUAL 0 $? "Already packaged installed should return a success code."
-    CHECK_CONTAINS "Package 'curl' is already installed." "$value"
+    CHECK_EQUAL 0 $? "Already packaged installed should return a success code." || return 1
+    CHECK_CONTAINS "Package 'curl' is already installed." "$value" || return 1
   }
   TEST "brew_package_tests" "test_brew_curl_already_installed"
 }
@@ -220,7 +222,7 @@ FIXTURE "ham_os_package_syslib"
 if [[ "$HAM_OS_PACKAGE_MANAGER" == "none" ]]; then
   # shellcheck disable=SC2317
   test__ham_os_package_syslib_no_package_manager() {
-    CHECK_EQUAL "NT" "$HAM_OS" "Only Windows doesnt have a package manager atm, got '$HAM_OS'."
+    CHECK_EQUAL "NT" "$HAM_OS" "Only Windows doesnt have a package manager atm, got '$HAM_OS'." || return 1
   }
   TEST "ham_os_package_syslib" "test__ham_os_package_syslib_no_package_manager"
 
@@ -229,56 +231,52 @@ else
   test__ham_os_package_syslib_find_file__curl_include() {
     local FUNC=test__ham_os_package_syslib_find_file__curl_include
     value=$(ham_os_package_syslib_find_file "include" "curl/curl.h" apt:libcurl4-openssl-dev pacman:curl brew:curl)
-    CHECK_EQUAL 0 $? "call should succeed"
+    CHECK_EQUAL 0 $? "call should succeed" || return 1
     log_info "... value: $value"
-    CHECK_CONTAINS "curl/curl.h" "$value" "curl/curl.h should exist in the include path"
+    CHECK_CONTAINS "curl/curl.h" "$value" "curl/curl.h should exist in the include path" || return 1
   }
   TEST "ham_os_package_syslib" "test__ham_os_package_syslib_find_file__curl_include"
-
-  # shellcheck disable=SC2317
-  test__ham_os_package_syslib_find_file__curl_lib() {
-    local FUNC=test__ham_os_package_syslib_find_file__curl_lib
-    value=$(ham_os_package_syslib_find_file "lib" "libcurl.so" apt:libcurl4-openssl-dev curl)
-    CHECK_EQUAL 0 $? "call should succeed"
-    log_info "... value: $value"
-    CHECK_CONTAINS "libcurl.so" "$value" "libcurl.so should exist in the lib path"
-  }
-  TEST "ham_os_package_syslib" "test__ham_os_package_syslib_find_file__curl_lib"
 
   # shellcheck disable=SC2317
   test__ham_os_package_syslib_check_and_install__curl_include() {
     local FUNC=test__ham_os_package_syslib_check_and_install__curl_include
     value=$(ham_os_package_syslib_check_and_install "include" "curl/curl.h" apt:libcurl4-openssl-dev pacman:curl brew:curl)
-    CHECK_EQUAL 0 $? "call should succeed"
+    CHECK_EQUAL 0 $? "call should succeed" || return 1
     log_info "... value: $value"
-    CHECK_CONTAINS "curl/curl.h" "$value" "curl/curl.h should be found after check/install"
+    CHECK_CONTAINS "curl/curl.h" "$value" "curl/curl.h should be found after check/install" || return 1
   }
   TEST "ham_os_package_syslib" "test__ham_os_package_syslib_check_and_install__curl_include"
 
   # shellcheck disable=SC2317
   test__ham_os_package_syslib_check_and_install__autossh_bin() {
+    log_info "Uninstalling autossh to test reinstall..."
     case "$HAM_OS_PACKAGE_MANAGER" in
       pacman)
-        log_info "Uninstalling autossh to test reinstall..."
         (
           set -ex
           sudo pacman -R --noconfirm autossh
         )
         ;;
+      brew)
+        (
+          set -ex
+          ham-brew uninstall autossh
+        )
+        ;;
       *)
-        log_warning "Don't know how to uninstall autossh."
+        log_warning "Don't know how to uninstall autossh with '$HAM_OS_PACKAGE_MANAGER'."
         ;;
     esac
-    CHECK_EQUAL 0 $? "uninstall of autossh should succeed"
+    CHECK_EQUAL 0 $? "uninstall of autossh should succeed" || return 1
 
     local FUNC=test__ham_os_package_syslib_check_and_install__autossh_bin
     value=$(ham_os_package_syslib_check_and_install "bin" "autossh" autossh)
-    CHECK_EQUAL 0 $? "install of autossh should succeed"
+    CHECK_EQUAL 0 $? "install of autossh should succeed" || return 1
     log_info "... value: $value"
     expected_path=$(ham_os_package_syslib_find_file "bin" "autossh" autossh)
     log_info "... expected_path: $expected_path"
-    CHECK_CONTAINS "autossh" "$value" "check_and_install output should at least contain autossh"
-    CHECK_EQUAL "$expected_path" "$value" "check_and_install should be consistent with ham_os_package_syslib_find_file"
+    CHECK_CONTAINS "autossh" "$value" "check_and_install output should at least contain autossh" || return 1
+    CHECK_EQUAL "$expected_path" "$value" "check_and_install should be consistent with ham_os_package_syslib_find_file" || return 1
   }
   TEST "ham_os_package_syslib" "test__ham_os_package_syslib_check_and_install__autossh_bin"
 
@@ -286,9 +284,9 @@ else
   test__ham_os_package_syslib_check_and_install__non_existent_package() {
     local FUNC=test__ham_os_package_syslib_check_and_install__non_existent_package
     value=$(ham_os_package_syslib_check_and_install "include" "wee_iamnotapackage.h" apt:wee_iamnotapackage-bla wee_iamnotapackage 2>&1)
-    CHECK_EQUAL 1 $? "call should fail"
+    CHECK_EQUAL 1 $? "call should fail" || return 1
     log_info "... value: $value"
-    CHECK_CONTAINS "ham_os_package_syslib_check_and_install: Unable to find 'wee_iamnotapackage.h' after installing package 'wee_iamnotapackage'" "$value" "curl/curl.h should be found after check/install"
+    CHECK_CONTAINS "ham_os_package_syslib_check_and_install: Unable to find 'wee_iamnotapackage.h' after installing package 'wee_iamnotapackage'" "$value" "curl/curl.h should be found after check/install" || return 1
   }
   TEST "ham_os_package_syslib" "test__ham_os_package_syslib_check_and_install__non_existent_package"
 fi

--- a/bin/ham-bash-lib-unittest-tests.sh
+++ b/bin/ham-bash-lib-unittest-tests.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# run:
+#   bash "$HAM_HOME/bin/ham-bash-lib-unittest-tests.sh"
+#
+if [[ -z "$HAM_HOME" ]]; then
+  echo "E/HAM_HOME not set !"
+  exit 1
+fi
+. "$HAM_HOME/bin/ham-bash-lib.sh"
+. "$HAM_HOME/bin/ham-bash-lib-unittest.sh"
+
+###########################################################################
+# TESTS: unittest library usage examples
+###########################################################################
+FIXTURE "basic_math"
+
+# shellcheck disable=SC2317
+test_addition() {
+  local result=$((2 + 2))
+  log_info "... result: $result"
+  CHECK_EQUAL 4 "$result" "2 + 2 should equal 4"
+}
+TEST "basic_math" "test_addition"
+
+# shellcheck disable=SC2317
+test_subtraction() {
+  local result=$((5 - 3))
+  log_info "... result: $result"
+  CHECK_EQUAL 2 "$result" "5 - 3 should equal 2"
+}
+TEST "basic_math" "test_subtraction"
+
+# shellcheck disable=SC2317
+test_bad_subtraction() {
+  local result=$((5 - 123))
+  log_info "... result: $result"
+  CHECK_EQUAL 2 "$result" "5 - 3 should equal 2"
+}
+TEST_SKIP "basic_math" "test_bad_subtraction"
+
+###########################################################################
+# RUN_TESTS
+###########################################################################
+RUN_TESTS "$1"
+exit $?

--- a/bin/ham-bash-lib-unittest.sh
+++ b/bin/ham-bash-lib-unittest.sh
@@ -1,0 +1,253 @@
+#!/bin/bash
+if [[ -z "$HAM_HOME" ]]; then
+  echo "E/HAM_HOME not set !"
+  exit 1
+fi
+
+###########################################################################
+# LIBRARY
+###########################################################################
+
+# Define fixtures and tests
+declare -A FIXTURES
+declare -a TESTS
+declare -a FAILED_TESTS
+
+# usage: CHECK_NOT_EQUAL cond (desc)
+#   CHECK macro to test boolean conditions
+CHECK() {
+  local condition=$1
+  local desc=$2
+
+  if ! $condition; then
+    complain "CHECK" "CHECK FAILED: $desc"
+    return 1
+  fi
+
+  return 0
+}
+
+# usage: CHECK_EQUAL expected value (desc)
+#   CHECK_EQUAL macro to compare two values
+CHECK_EQUAL() {
+  local expected=$1
+  local actual=$2
+  local desc=$3
+
+  if [[ "$expected" != "$actual" ]]; then
+    if [ -n "$desc" ]; then
+      complain "CHECK_EQUAL" "$desc"
+    else
+      complain "CHECK_EQUAL" "Expected both values to be equal."
+    fi
+    echo "EXPECTED: $expected"
+    echo "  ACTUAL: $actual"
+    return 1
+  fi
+
+  return 0
+}
+
+# usage: CHECK_NOT_EQUAL expected value (desc)
+#   CHECK_NOT_EQUAL macro to compare two values
+CHECK_NOT_EQUAL() {
+  local expected=$1
+  local actual=$2
+  local desc=$3
+
+  if [[ "$expected" == "$actual" ]]; then
+    if [ -n "$desc" ]; then
+      complain "CHECK_NOT_EQUAL" "$desc"
+    else
+      complain "CHECK_NOT_EQUAL" "Expected both values to be different."
+    fi
+    echo "EXPECTED: $expected"
+    echo "  ACTUAL: $actual"
+    return 1
+  fi
+
+  return 0
+}
+
+# usage: CHECK_CONTAINS expected value (desc)
+#   CHECK_CONTAINS macro that the value contains the expected value
+CHECK_CONTAINS() {
+  local expected=$1
+  local actual=$2
+  local desc=$3
+
+  if [[ "$actual" != *"$expected"* ]]; then
+    if [ -n "$desc" ]; then
+      complain "CHECK_CONTAINS" "$desc"
+    else
+      complain "CHECK_CONTAINS" "Expected value should be contained in the actual value."
+    fi
+    echo "EXPECTED: $expected"
+    echo "  ACTUAL: $actual"
+    return 1
+  fi
+
+  return 0
+}
+
+# usage: FIXTURE name
+#   Define a fixture
+FIXTURE() {
+  local fixture_name=$1
+  FIXTURES["$fixture_name"]=1
+}
+
+_TEST_VALIDATE() {
+  local func=$1
+  local fixture=$2
+  local test_name=$3
+  local full_name="$fixture:$test_name"
+
+  # Check if fixture is defined
+  if [[ -z "${FIXTURES[$fixture]}" ]]; then
+    complain "$func" "'$full_name' fixture '$fixture' does not exist."
+    exit 1
+  fi
+
+  # Check if test_name is provided and the corresponding function is defined
+  if [[ -z "$test_name" ]]; then
+    complain "$func" "'$full_name' test name is not specified."
+    exit 1
+  elif ! declare -f "$test_name" >/dev/null; then
+    complain "$func" "'$full_name' test function '$test_name' does not exist."
+    exit 1
+  fi
+}
+
+# usage: TEST fixture_name test_and_func_name
+#   Define a test within a fixture
+TEST() {
+  local fixture=$1
+  local test_name=$2
+  _TEST_VALIDATE TEST "$fixture" "$test_name" || return 1
+  TESTS+=("$fixture:$test_name")
+}
+
+# usage: TEST_SKIP fixture_name test_and_func_name
+#   Define a skipped test within a fixture
+TEST_SKIP() {
+  local fixture=$1
+  local test_name=$2
+  _TEST_VALIDATE TEST_SKIP "$fixture" "$test_name" || return 1
+  TESTS+=("__skip__:$fixture:$test_name")
+}
+
+# usage: RUN_TESTS (filter)
+#   Run tests, filtered by fixture or test name
+RUN_TESTS() {
+  local filter=$1
+  local total=0
+  local failed=0
+  local succeeded=0
+  local skipped=0
+
+  for test in "${TESTS[@]}"; do
+    if [[ -z "$filter" || "$test" == *"$filter"* ]]; then
+      ((total++))
+
+      if [[ "$test" == __skip__* ]]; then
+        ((skipped++))
+        local test_name
+        test_name=$(echo "$test" | cut -d':' -f2-)
+        local test_func_name
+        test_func_name=$(echo "$test_name" | cut -d':' -f2-)
+        if [[ "$test_name" == "$filter" || "$test_func_name" == "$filter" ]]; then
+          log_info "Exact filter match of skipped test, force run it."
+          test=$test_name
+        else
+          echo "### skipped: $test_name ###"
+          continue
+        fi
+      fi
+
+      local fixture
+      fixture=$(echo "$test" | cut -d':' -f1)
+      local test_func_name
+      test_func_name=$(echo "$test" | cut -d':' -f2)
+      echo "### $test ###"
+
+      # Run the test by dynamically invoking the function
+      eval "$test_func_name"
+      local result=$?
+
+      if [[ $result -eq 0 ]]; then
+        log_success "SUCCEEDED '$test'"
+        ((succeeded++))
+      else
+        log_error "FAILED '$test'"
+        ((failed++))
+        FAILED_TESTS+=("$test")
+      fi
+    fi
+  done
+
+  echo "### $total tests ###"
+  if [[ "$total" == "0" ]]; then
+    log_error "No test found for filter '$filter'."
+    return 1
+  elif [[ "$succeeded" == "0" ]]; then
+    log_error "All failed, '$skipped' skipped."
+    return 1
+  elif [[ "$failed" == "0" ]]; then
+    log_success "All succeeded, '$skipped' skipped."
+    return 0
+  else
+    log_error "Some failed: '$failed' failed, '$succeeded' succeeded, '$skipped' skipped."
+    echo "Failed tests:"
+    for failed_test in "${FAILED_TESTS[@]}"; do
+      echo "- $failed_test"
+    done
+    return 1
+  fi
+}
+
+###########################################################################
+# TESTING, run with:
+#   bash "$HAM_HOME/bin/ham-bash-lib-unittest.sh" unittest-unittest
+#   # Exact match of skipped test name force runs it
+#   bash "$HAM_HOME/bin/ham-bash-lib-unittest.sh" unittest-unittest test_bad_subtraction
+###########################################################################
+if [[ "$1" == "unittest-unittest" ]]; then
+  shift
+
+  ###########################################################################
+  # TESTS: unittest library usage examples
+  ###########################################################################
+  FIXTURE "basic_math"
+
+  # shellcheck disable=SC2317
+  test_addition() {
+    local result=$((2 + 2))
+    log_info "... result: $result"
+    CHECK_EQUAL 4 "$result" "2 + 2 should equal 4"
+  }
+  TEST "basic_math" "test_addition"
+
+  # shellcheck disable=SC2317
+  test_subtraction() {
+    local result=$((5 - 3))
+    log_info "... result: $result"
+    CHECK_EQUAL 2 "$result" "5 - 3 should equal 2"
+  }
+  TEST "basic_math" "test_subtraction"
+
+  # shellcheck disable=SC2317
+  test_bad_subtraction() {
+    local result=$((5 - 123))
+    log_info "... result: $result"
+    CHECK_EQUAL 2 "$result" "5 - 3 should equal 2"
+  }
+  TEST_SKIP "basic_math" "test_bad_subtraction"
+
+  ###########################################################################
+  # RUN_TESTS
+  ###########################################################################
+  RUN_TESTS "$1"
+  exit $?
+
+fi # if [[ "$1" == "unittest" ]]

--- a/bin/ham-bash-lib-unittest.sh
+++ b/bin/ham-bash-lib-unittest.sh
@@ -40,8 +40,8 @@ CHECK_EQUAL() {
     else
       complain "CHECK_EQUAL" "Expected both values to be equal."
     fi
-    echo "EXPECTED: $expected"
-    echo "  ACTUAL: $actual"
+    echo "EXPECTED: <<<$expected>>>"
+    echo "  ACTUAL: <<<$actual>>>"
     return 1
   fi
 
@@ -61,8 +61,8 @@ CHECK_NOT_EQUAL() {
     else
       complain "CHECK_NOT_EQUAL" "Expected both values to be different."
     fi
-    echo "EXPECTED: $expected"
-    echo "  ACTUAL: $actual"
+    echo "EXPECTED: <<<$expected>>>"
+    echo "  ACTUAL: <<<$actual>>>"
     return 1
   fi
 
@@ -82,8 +82,8 @@ CHECK_CONTAINS() {
     else
       complain "CHECK_CONTAINS" "Expected value should be contained in the actual value."
     fi
-    echo "EXPECTED: $expected"
-    echo "  ACTUAL: $actual"
+    echo "EXPECTED: <<<$expected>>>"
+    echo "  ACTUAL: <<<$actual>>>"
     return 1
   fi
 

--- a/bin/ham-bash-lib.sh
+++ b/bin/ham-bash-lib.sh
@@ -1006,10 +1006,26 @@ function ham_os_package_syslib_find_file() {
       echo "$INSTALL_DIR/$FILE"
       return 0
     fi
+
+    if [[ -n "$(ham_find_which_path xcrun)" ]]; then
+      INSTALL_DIR=$(xcrun --show-sdk-path)/usr/$TYPE
+      if [[ -f "$INSTALL_DIR/$FILE" ]]; then
+        echo "$INSTALL_DIR/$FILE"
+        return 0
+      fi
+    fi
   else
     # For other package managers, use ham_os_package_find_in_usr_dir
     ham_os_package_find_in_usr_dir "$TYPE" "$FILE"
     return 0
+  fi
+
+  # if its a binary we allow the path to work aswell
+  if [[ "$TYPE" == "bin" ]]; then
+    EXE_PATH=$(ham_find_which_path "$FILE")
+    if [[ -e "$EXE_PATH" ]]; then
+      echo "$EXE_PATH"
+    fi
   fi
 }
 

--- a/bin/ham-bash-lib.sh
+++ b/bin/ham-bash-lib.sh
@@ -856,6 +856,15 @@ ham_os_package_find_in_usr_dir() {
 
   # Search for the file in a few directories
   SEARCH_DIRS=("/usr/$TYPE" "/usr/local/$TYPE")
+
+  if [[ "$HAM_BIN_LOA" == "lin-x64" && "$HAM_OS_PACKAGE_MANAGER" == "apt" ]]; then
+    ARCH_USR_DIR="/usr/$TYPE/x86_64-linux-gnu"
+    if [[ -d "$ARCH_USR_DIR" ]]; then
+      # Append to SEARCH_DIRS
+      SEARCH_DIRS+=("$ARCH_USR_DIR")
+    fi
+  fi
+
   for DIR in "${SEARCH_DIRS[@]}"; do
     local TRY_PATH="$DIR/$FILE"
     if [[ -e "$TRY_PATH" ]]; then

--- a/bin/ham-bash-setenv.sh
+++ b/bin/ham-bash-setenv.sh
@@ -52,6 +52,7 @@ if [ "${HAM_ENV_SETUP}" != 1 ]; then
       echo "W/ham-bash-setenv.sh: Unknown HAM_OS: $HAM_OS"
       ;;
   esac
+
   pathenv_add "$HAM_HOME/bin/$HAM_BIN_LOA"
   # This must be called after bin/HAM_BIN_LOA so that they
   # get before it in the PATH list.
@@ -62,6 +63,10 @@ if [ "${HAM_ENV_SETUP}" != 1 ]; then
   # Sanitize HAM_HOME's path
   HAM_HOME=$(abspath "$HAM_HOME")
   export HAM_HOME
+
+  # Detect the package manager
+  HAM_OS_PACKAGE_MANAGER=$(ham_os_package_detect_default_manager)
+  export HAM_OS_PACKAGE_MANAGER
 else
   true
 fi

--- a/bin/ham-env-clear
+++ b/bin/ham-env-clear
@@ -1,5 +1,5 @@
 #!/bin/bash
-TO_UNSET=$(ham-env | grep -E -vw 'WORK|HAM_OS|HAM_HOME|HAM_CMD|HAM_BIN_LOA|HAM_NO_VER_CHECK|HAM_CPPM_FORCE_BUILD|HAM_TOOLSET_DL_URL|BUILD_TARGET' | cut -d= -f1)
+TO_UNSET=$(ham-env | grep -E -vw 'WORK|HAM_OS|HAM_OS_PACKAGE_MANAGER|HAM_HOME|HAM_CMD|HAM_BIN_LOA|HAM_NO_VER_CHECK|HAM_CPPM_FORCE_BUILD|HAM_TOOLSET_DL_URL|BUILD_TARGET' | cut -d= -f1)
 # echo "TO_UNSET: $TO_UNSET"
 # shellcheck disable=SC2086 # We actually want word splitting here
 unset $TO_UNSET

--- a/bin/ham-toolset-do-import.sh
+++ b/bin/ham-toolset-do-import.sh
@@ -19,11 +19,24 @@ fi
 
 SETUP_SCRIPT=
 FOUND_SETUP_SCRIPT=no
+
+# Look in HAM_HOME/specs for the toolset definition
 if [ "$FOUND_SETUP_SCRIPT" == "no" ]; then
   DIR="${HAM_HOME}/specs/toolsets/$1"
   SETUP_SCRIPT="$DIR/setup-toolset.sh"
   if [ -f "$SETUP_SCRIPT" ]; then
     FOUND_SETUP_SCRIPT="from GLOBAL."
+  fi
+fi
+
+# Look in HAM_PROJECT_DIR/specs for the toolset definition, this is the
+# directory of the current _ham_project
+if [[ -d "${HAM_PROJECT_DIR}" && "$FOUND_SETUP_SCRIPT" == "no" ]]; then
+  DIR="${HAM_PROJECT_DIR}/specs/toolsets/$1"
+  log_info "TRY PROJECT: $DIR"
+  SETUP_SCRIPT="$DIR/setup-toolset.sh"
+  if [ -f "$SETUP_SCRIPT" ]; then
+    FOUND_SETUP_SCRIPT="from PROJECT."
   fi
 fi
 

--- a/bin/has_inpath
+++ b/bin/has_inpath
@@ -9,6 +9,5 @@ path=$(ham_find_which_path "$*")
 if [ -z "$path" ]; then
   exit 1
 else
-  echo -n "$path"
   exit 0
 fi

--- a/rules/base-GCC-rules.ham
+++ b/rules/base-GCC-rules.ham
@@ -5,5 +5,10 @@ actions SharedLink {
 
 actions DllLink bind NEEDLIBS
 {
-  $(LINK) $(LINKFLAGS) $(LINKFLAGS_DLL) -fvisibility=hidden -shared -o "$(<)" $(UNDEFS) "$(>)" $(NEEDLIBS) $(LINKLIBS) $(SYSTEM_LINKLIBS)
+  $(LINK) $(LINKFLAGS) $(LINKFLAGS_DLL) -Wl,--no-undefined -shared -o "$(<)" $(UNDEFS) -Wl,--start-group $(NEEDLIBS) $(LINKLIBS) "$(>)" -Wl,--end-group $(SYSTEM_LINKLIBS)
+}
+
+actions Link bind NEEDLIBS
+{
+  $(LINK) $(LINKFLAGS) $(LINKFLAGS_EXE) -Wl,--no-undefined -o "$(<)" $(UNDEFS) -Wl,--start-group $(NEEDLIBS) $(LINKLIBS) "$(>)" -Wl,--end-group $(SYSTEM_LINKLIBS)
 }

--- a/rules/base.ham
+++ b/rules/base.ham
@@ -1121,14 +1121,6 @@ rule SharedLibrary
   SharedObjects            $(>) ;
 }
 
-# Same as SharedLibrary, but also output a static library along side the dll
-rule SharedAndStaticLibrary
-{
-  SharedLibraryFromObjects $(<) : $(>:S=$(SUFDLLOBJ)) $(5) : $(3) : $(4) ;
-  LibraryFromObjects $(<) : $(>:S=$(SUFOBJ)) $(5) ;
-  SharedObjects $(>) ;
-}
-
 # /LibraryFromObjects library : objects ;
 #
 # Archives _objects_ into _library_. The _objects_ are then deleted

--- a/rules/base.ham
+++ b/rules/base.ham
@@ -702,6 +702,12 @@ SUFOBJ      ?= .o ;
 UNDEFFLAG   ?= "-u _" ;
 RCFLAGS     ?= ;
 SUFJAVAC    ?= .class ;
+if $(OS) = NT {
+  HAM_EXEC_RETRY ?= ham-exec-retry ;
+}
+else {
+  HAM_EXEC_RETRY ?= ;
+}
 
 HDRPATTERN =
 "^[ 	]*#[ 	]*include[ 	]*[<\"]([^\">]*)[\">].*$" ;
@@ -2397,38 +2403,38 @@ actions LintH
 
 actions Chgrp
 {
-  ham-exec-retry $(CHGRP) $(GROUP) "$(<)"
+  $(HAM_EXEC_RETRY) $(CHGRP) $(GROUP) "$(<)"
 }
 
 actions Chmod1
 {
-  ham-exec-retry $(CHMOD) $(MODE) "$(<)"
+  $(HAM_EXEC_RETRY) $(CHMOD) $(MODE) "$(<)"
 }
 
 actions Chown
 {
-  ham-exec-retry $(CHOWN) $(OWNER) "$(<)"
+  $(HAM_EXEC_RETRY) $(CHOWN) $(OWNER) "$(<)"
 }
 
 actions piecemeal together existing Clean
 {
-  ham-exec-retry $(RM) "$(>)"
+  $(HAM_EXEC_RETRY) $(RM) "$(>)"
 }
 
 actions Cp
 {
-  ham-exec-retry $(CP) "$(>)" "$(<)"
+  $(HAM_EXEC_RETRY) $(CP) "$(>)" "$(<)"
 }
 
 rule Touch {
 }
 actions Touch {
-  ham-exec-retry touch "$(<)"
+  $(HAM_EXEC_RETRY) touch "$(<)"
 }
 
 actions File
 {
-  ham-exec-retry $(CP) "$(>)" "$(<)"
+  $(HAM_EXEC_RETRY) $(CP) "$(>)" "$(<)"
 }
 
 
@@ -2452,15 +2458,15 @@ if $(OS) = MACOSX {
 else {
   actions FilePreserveRO
   {
-    ham-exec-retry $(CP_PRESERVE) "$(>)" "$(<)"
+    $(HAM_EXEC_RETRY) $(CP_PRESERVE) "$(>)" "$(<)"
   }
   actions FilePreserveEXE
   {
-    ham-exec-retry $(CP_PRESERVE) "$(>)" "$(<)"
+    $(HAM_EXEC_RETRY) $(CP_PRESERVE) "$(>)" "$(<)"
   }
   actions FilePreserve
   {
-    ham-exec-retry $(CP_PRESERVE) "$(>)" "$(<)"
+    $(HAM_EXEC_RETRY) $(CP_PRESERVE) "$(>)" "$(<)"
   }
 }
 
@@ -2478,7 +2484,7 @@ else {
 
 actions HardLink
 {
-  ham-exec-retry $(RM) "$(<)" && $(LN) "$(>)" "$(<)"
+  $(HAM_EXEC_RETRY) $(RM) "$(<)" && $(LN) "$(>)" "$(<)"
 }
 
 actions Link bind NEEDLIBS
@@ -2498,12 +2504,12 @@ actions together Ranlib
 
 actions quietly updated piecemeal together RmTemps
 {
-  ham-exec-retry $(RM) "$(>)"
+  $(HAM_EXEC_RETRY) $(RM) "$(>)"
 }
 
 actions SoftLink
 {
-  ham-exec-retry $(RM) "$(<)" && $(LN) -s "$(>)" "$(<)"
+  $(HAM_EXEC_RETRY) $(RM) "$(<)" && $(LN) -s "$(>)" "$(<)"
 }
 
 # The the absolute path of the specified path, using / as file separator

--- a/rules/ham-toolset.ham
+++ b/rules/ham-toolset.ham
@@ -23,6 +23,7 @@ rule hamToolsetHdrs {
   else {
     # logFatal "hamToolsetHdrs: $(toolsetName), can't find include directory:" $(d) ;
   }
+  return $(d) ;
 }
 
 rule hamToolsetDll {

--- a/rules/toolkit-base-clang_18.ham
+++ b/rules/toolkit-base-clang_18.ham
@@ -1,0 +1,2 @@
+Import toolkit-base-gcc_470.ham ;
+LOA_LINKER = clang ;

--- a/rules/toolkit-cpp-clang_18.ham
+++ b/rules/toolkit-cpp-clang_18.ham
@@ -1,0 +1,13 @@
+Import toolkit-cpp-clang_33.ham ;
+
+CLANG_CPP_ARGS +=
+  # Disable: warning: variable length arrays in C++ are a Clang extension
+  -Wno-vla-cxx-extension
+;
+
+if $(LINUX) {
+  LINKFLAGS +=
+    # More compatible, should work on Arch/SteamOS & Ubuntu
+    --unwindlib=libgcc
+  ;
+}

--- a/rules/toolkit-cpp-clang_33.ham
+++ b/rules/toolkit-cpp-clang_33.ham
@@ -85,8 +85,6 @@ if $(LINUX) {
 
   LINKLIBS +=
    -lstdc++ -lpthread -ldl -lm
-   # sudo apt-get install -y libunwind-dev
-   -lunwind
   ;
 
   # Flags needed so that backtrace() include the function names on Linux

--- a/rules/toolkit-cpp-clang_33.ham
+++ b/rules/toolkit-cpp-clang_33.ham
@@ -6,6 +6,7 @@ if $(BUILD) = da {
 STRICT_ALIASING_FLAGS = -fno-strict-aliasing ;
 
 CLANG_CC_ARGS +=
+  -fvisibility=hidden
   -ffunction-sections
   -fdata-sections
   -fvisibility=hidden
@@ -37,12 +38,6 @@ if $(C++VERSION) >= 20 {
     -Wno-deprecated-builtins
   ;
 }
-
-LINKFLAGS +=
-  -fvisibility=hidden
-  -ffunction-sections
-  -fdata-sections
-;
 
 if $(FLYMAKE) = 1 {
   # Happens when we're compiling header files with flymake since the temporary
@@ -84,16 +79,7 @@ if $(LINUX) {
   ;
 
   LINKLIBS +=
-   -lstdc++ -lpthread -ldl -lm
-  ;
-
-  # Flags needed so that backtrace() include the function names on Linux
-  CLANG_CC_ARGS +=
-    -fvisibility=default
-  ;
-  LINKLIBS +=
-    -fvisibility=default
-    -rdynamic
+    -lstdc++ -lpthread -ldl -lm
   ;
 }
 

--- a/rules/toolkit-cpp-gcc.ham
+++ b/rules/toolkit-cpp-gcc.ham
@@ -1,12 +1,14 @@
 STRICT_ALIASING_FLAGS ?= -fno-strict-aliasing ;
 
 GCC_CC_ARGS +=
+  -fvisibility=hidden
   -ffunction-sections
   -fdata-sections
   -fvisibility=hidden
   -Wno-switch
   -Wno-unused-value
 ;
+
 GCC_CPP_ARGS +=
   -std=$(C++VERSION)
   -Wno-narrowing
@@ -14,9 +16,7 @@ GCC_CPP_ARGS +=
 ;
 
 LINKFLAGS +=
-  -fvisibility=hidden
-  -ffunction-sections
-  -fdata-sections
+  -Wl,--gc-sections
 ;
 
 ### OSX ###
@@ -48,9 +48,9 @@ if $(LINUX) {
   ;
 
   ### "Debug" (da) build flags ###
-  CLANG_DBG_ARGS ?= -ggdb -O0 $(STRICT_ALIASING_FLAGS) ;
+  GCC_DBG_ARGS ?= -ggdb -O0 $(STRICT_ALIASING_FLAGS) ;
   ### Optimized (ra) build flags ###
-  CLANG_OPT_ARGS ?= -ggdb -O2 $(STRICT_ALIASING_FLAGS) ;
+  GCC_OPT_ARGS ?= -ggdb -O2 $(STRICT_ALIASING_FLAGS) ;
 }
 
 CCFLAGS   += $(GCC_CC_ARGS) ;
@@ -66,12 +66,12 @@ rule tkCC++Build
   # Set the debug infos generation
   # Set the optimization flags
   if $(DEBUG) = 1 {
-    PKGOPTIM += $(CLANG_DBG_ARGS) ;
+    PKGOPTIM += $(GCC_DBG_ARGS) ;
     strOpt += "(DebugOnly) " ;
   }
   # Set debug-only flags
   else {
-    PKGOPTIM += $(CLANG_OPT_ARGS) ;
+    PKGOPTIM += $(GCC_OPT_ARGS) ;
     strOpt += "(Optimized) " ;
   }
   logVerbose "- CC++Build: " $(strOpt) ;

--- a/rules/toolkit-cpp-gcc.ham
+++ b/rules/toolkit-cpp-gcc.ham
@@ -45,8 +45,6 @@ if $(LINUX) {
   }
   LINKLIBS +=
    -lstdc++ -lpthread -ldl -lm
-   # sudo apt-get install -y libunwind-dev
-   -lunwind
   ;
 
   ### "Debug" (da) build flags ###

--- a/rules/toolkit-cpp-zigcc.ham
+++ b/rules/toolkit-cpp-zigcc.ham
@@ -94,7 +94,7 @@ if $(TARGET_OS) = MACOSX {
   -framework MetalKit
   -framework QuartzCore
   -framework Security
-  -lc++ -lpthread -ldl -lunwind ;
+  -lc++ -lpthread -ldl ;
 }
 else if $(TARGET_OS) = LINUX {
 
@@ -107,7 +107,7 @@ else if $(TARGET_OS) = LINUX {
     LINKFLAGS_DLL += -dead_strip ;
   }
   LINKLIBS +=
-    -lstdc++ -lpthread -ldl -lm -lunwind
+    -lstdc++ -lpthread -ldl -lm
   ;
 }
 else {

--- a/rules/toolkit.ham
+++ b/rules/toolkit.ham
@@ -905,6 +905,9 @@ rule tkBuildPackage
   ObjectOptimFlags $(_exsrc) $(_src) $(_nopchsrc) : $(PKGOPTIM) ;
   OPTIM on $(_pch) = $(PKGOPTIM) ;
 
+  ### List of built files ###
+  local f = ;
+
   ### Main build output ###
   _src += $(_nopchsrc) ;
 
@@ -913,11 +916,19 @@ rule tkBuildPackage
   logVar PKGBUILD ;
   if $(PKGTYPE) = dll || $(PKGTYPE) = tooldll {
     ObjectDefines $(_allsrc) : _TARGET_DLL ;
+    SharedLibrary $(t) : $(_src) : : : $(_extra_objs) ;
+
     if $(PKGTARGET_LIB) {
-      SharedAndStaticLibrary $(t) : $(_src) : : : $(_extra_objs) ;
-    }
-    else {
-      SharedLibrary $(t) : $(_src) : : : $(_extra_objs) ;
+      local tlib_obj = [ FDirName $(OBJDIR) $(PKGTARGET_LIB) ] ;
+      Library $(tlib_obj) : $(_src) : $(_extra_objs) ;
+      DEPENDS $(PACKAGE)_lib : $(tlib_obj) ;
+      f += $(tlib_obj) ;
+      if $(_cpredist) = 1 {
+        local tlib_redist = [ FDirName $(TK_DIR_LIBS) $(PKGTARGET_LIB:B)$(_stamp)$(PKGTARGET_LIB:S) ] ;
+        FilePreserve $(tlib_redist) : $(tlib_obj) ;
+        DEPENDS $(PACKAGE)_lib : $(tlib_redist) ;
+        f += $(tlib_redist) ;
+      }
     }
   }
   else if $(PKGTYPE) = library {
@@ -933,7 +944,6 @@ rule tkBuildPackage
   ### Copy into the redist/output directory ###
   local d = $(PKGTARGET) ;
   DEPENDS $(d) : tkdir ;
-  local f = ;
   if $(_cpredist) = 1 {
     local p = [ tkFile $(PKGTARGETF:B)$(_stamp)$(PKGTARGETF:S) : $(d) : $(OUTDIR) ] ;
     if $(is_exe) {
@@ -941,12 +951,6 @@ rule tkBuildPackage
       Chmod $(p) ;
     }
     f += $(p) ;
-
-    if $(PKGTARGET_LIB) {
-      local p = [ tkFile $(PKGTARGET_LIB:B)$(_stamp)$(PKGTARGET_LIB:S) : $(PKGTARGET_LIB) : $(TK_DIR_LIBS) ] ;
-      DEPENDS $(PACKAGE)_lib : $(p) ;
-      f += $(p) ;
-    }
 
     if $(PKGTARGET_JS) {
       local p = [ tkFile $(PKGTARGET_JS:B)$(_stamp)$(PKGTARGET_JS:S) : $(PKGTARGET_JS) : $(TK_DIR_BIN) ] ;
@@ -962,11 +966,6 @@ rule tkBuildPackage
   }
   else {
     f += $(d) ;
-
-    if $(PKGTARGET_LIB) {
-      f += $(PKGTARGET_LIB) ;
-      DEPENDS $(PACKAGE)_lib : $(PKGTARGET_LIB) ;
-    }
 
     if $(PKGTARGET_JS) {
       f += $(PKGTARGET_JS) ;

--- a/scripts/ham.ni
+++ b/scripts/ham.ni
@@ -1,11 +1,8 @@
 // Copyright 2007-2016 TalanSoft, Co. All Rights Reserved.
 ::Import("lang.ni")
 ::Import("fs.ni")
-local __lint = {
-  this_set_key_notfound = 0
-}
 
-local module = {
+module <- {
   _osArch = null
   _build = null
   _hamPath = null
@@ -185,8 +182,8 @@ local module = {
     throw "Can't find the temp folder."
   }
 
-  function getNewTempFilePath(aExt,aName) {
-    local path = getTempDir().setfile((aName || "")+::gLang.CreateGlobalUUID()).setext(aExt || "tmp")
+  function getNewTempFilePath(aExt,_aName) {
+    local path = getTempDir().setfile((_aName || "")+::gLang.CreateGlobalUUID()).setext(aExt || "tmp")
     _tempFilesCollector.Add(path)
     if (_debugEchoAll) {
       ::dbg("... Added temp file:" path)
@@ -393,8 +390,7 @@ local module = {
                      tmpFilePath, aScript));
     }
     return runDetachedProcess(
-      getBashPath().quote() + " " + tmpFilePath.quote(),
-      true,true)
+      getBashPath().quote() + " " + tmpFilePath.quote())
   }
 
   function seqRawBash(aScript,aOptions) {
@@ -450,8 +446,7 @@ local module = {
                      tmpFilePath, aScript));
     }
     return runDetachedProcess(
-      getBashPath().quote() + " " + tmpFilePath.quote(),
-      true,true)
+      getBashPath().quote() + " " + tmpFilePath.quote())
   }
 
   function seqBash(aScript,aOptions) {
@@ -466,19 +461,15 @@ local module = {
   }
 }
 
-if (::isModule(this)) {
-  this.module = module
-}
-else {
-  ::namespace("ham", module);
+::?LINT_CHECK_TYPE("null", ::?ham);
+::ham <- module
 
-  function ::bash(aScript) {
-    return ::ham.runBash(aScript,true,true)
-  }
-  function ::bashDetached(aScript) {
-    return ::ham.runDetachedBash(aScript)
-  }
-  function ::bashSeq(aScript) {
-    return ::ham.seqBash(aScript)
-  }
+function ::bash(aScript) {
+  return ::ham.runBash(aScript,true,true)
+}
+function ::bashDetached(aScript) {
+  return ::ham.runDetachedBash(aScript)
+}
+function ::bashSeq(aScript) {
+  return ::ham.seqBash(aScript, null)
 }

--- a/sources/ham/src/compile.c
+++ b/sources/ham/src/compile.c
@@ -15,15 +15,15 @@
  *	compile_foreach() - compile the "for x in y" statement
  *	compile_if() - compile 'if' rule
  *	compile_include() - support for 'include' - call include() on file
- *	compile_list() - expand and return a list 
+ *	compile_list() - expand and return a list
  *	compile_local() - declare (and set) local variables
  *	compile_null() - do nothing -- a stub for parsing
  *	compile_on() - run rule under influence of on-target variables
  *	compile_rule() - compile a single user defined rule
  *	compile_rules() - compile a chain of rules
  *	compile_set() - compile the "set variable" statement
- *	compile_setcomp() - support for `rule` - save parse tree 
- *	compile_setexec() - support for `actions` - save execution string 
+ *	compile_setcomp() - support for `rule` - save parse tree
+ *	compile_setexec() - support for `actions` - save execution string
  *	compile_settings() - compile the "on =" (set variable on exec) statement
  *	compile_switch() - compile 'switch' rule
  *
@@ -32,7 +32,7 @@
  *	debug_compile() - printf with indent to show rule expansion.
  *	evaluate_rule() - execute a rule invocation
  *
- * 02/03/94 (seiwald) -	Changed trace output to read "setting" instead of 
+ * 02/03/94 (seiwald) -	Changed trace output to read "setting" instead of
  *			the awkward sounding "settings".
  * 04/12/94 (seiwald) - Combined build_depends() with build_includes().
  * 04/12/94 (seiwald) - actionlist() now just appends a single action.
@@ -56,7 +56,7 @@
  * 01/21/01 (seiwald) - replace evaluate_if() with compile_eval()
  * 01/24/01 (seiwald) - 'while' statement
  * 03/23/01 (seiwald) - "[ on target rule ]" support
- * 02/28/02 (seiwald) - merge EXEC_xxx flags in with RULE_xxx 
+ * 02/28/02 (seiwald) - merge EXEC_xxx flags in with RULE_xxx
  * 03/02/02 (seiwald) - rules can be invoked via variable names
  * 03/12/02 (seiwald) - &&,&,||,|,in now short-circuit again
  * 03/25/02 (seiwald) - if ( "" a b ) one again returns true
@@ -357,7 +357,7 @@ LIST *compile_include(PARSE *parse, LOL *args, int *jmp) {
 }
 
 /*
- * compile_list() - expand and return a list 
+ * compile_list() - expand and return a list
  *
  * 	parse->string - character string to expand
  */
@@ -435,8 +435,8 @@ LIST *compile_on(PARSE *parse, LOL *args, int *jmp) {
     printf("\n");
   }
 
-  /* 
-	 * Copy settings, so that 'on target var on target = val' 
+  /*
+	 * Copy settings, so that 'on target var on target = val'
 	 * doesn't set var globally.
 	 */
 
@@ -507,8 +507,10 @@ LIST *evaluate_rule(const char *rulename, LOL *args, LIST *result) {
 
   /* Check traditional targets $(<) and sources $(>) */
 
-  if (!rule->actions && !rule->procedure)
-    printf("warning: unknown rule %s\n", rule->name);
+  if (!rule->actions && !rule->procedure) {
+    fprintf(stderr, "error: unknown rule %s\n", rule->name);
+    exit(EXITBAD);
+  }
 
   /* If this rule will be executed for updating the targets */
   /* then construct the action for make(). */
@@ -597,7 +599,7 @@ LIST *compile_rules(PARSE *parse, LOL *args, int *jmp) {
  * compile_set() - compile the "set variable" statement
  *
  *	parse->left	variable names
- *	parse->right	variable values 
+ *	parse->right	variable values
  *	parse->num	VAR_SET/APPEND/DEFAULT
  */
 
@@ -626,7 +628,7 @@ LIST *compile_set(PARSE *parse, LOL *args, int *jmp) {
 }
 
 /*
- * compile_setcomp() - support for `rule` - save parse tree 
+ * compile_setcomp() - support for `rule` - save parse tree
  *
  *	parse->string	rule name
  *	parse->left	list of argument names
@@ -670,7 +672,7 @@ LIST *compile_setcomp(PARSE *parse, LOL *args, int *jmp) {
 }
 
 /*
- * compile_setexec() - support for `actions` - save execution string 
+ * compile_setexec() - support for `actions` - save execution string
  *
  *	parse->string	rule name
  *	parse->string1	OS command string
@@ -703,8 +705,8 @@ LIST *compile_setexec(PARSE *parse, LOL *args, int *jmp) {
  * compile_settings() - compile the "on =" (set variable on exec) statement
  *
  *	parse->left	variable names
- *	parse->right	target name 
- *	parse->third	variable value 
+ *	parse->right	target name
+ *	parse->third	variable value
  *	parse->num	VAR_SET/APPEND/DEFAULT
  */
 

--- a/sources/ham/src/patchlevel.h
+++ b/sources/ham/src/patchlevel.h
@@ -1,4 +1,4 @@
 /* Keep JAMVERSYM in sync with VERSION. */
 /* It can be accessed as $(JAMVERSION) in the Jamfile. */
-#define VERSION "21 (" __DATE__ " - " __TIME__ ")"
-#define JAMVERSYM "JAMVERSION=21"
+#define VERSION "22 (" __DATE__ " - " __TIME__ ")"
+#define JAMVERSYM "JAMVERSION=22"

--- a/sources/ham/src/scan.c
+++ b/sources/ham/src/scan.c
@@ -52,7 +52,7 @@ static char *symdump(YYSTYPE *s);
 
 #define BIGGEST_TOKEN 10240 /* no single token can be larger */
 
-/* 
+/*
  * Set parser mode: normal, string, or keyword
  */
 
@@ -131,8 +131,10 @@ int yyline() {
   if (!i->file) {
     FILE *f = stdin;
 
-    if (strcmp(i->fname, "-") && !(f = fopen(i->fname, "r")))
+    if (strcmp(i->fname, "-") && !(f = fopen(i->fname, "r"))) {
       perror(i->fname);
+      yyerror("cant open input/include file");
+     }
 
     i->file = f;
   }

--- a/specs/toolsets/clang_18/setup-toolset.sh
+++ b/specs/toolsets/clang_18/setup-toolset.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+toolset_import_once xslt_tools || return 1
+
+# We're using clang...
+export LINUX_CLANG=1
+
+# Use clang
+export HAM_TOOLSET=CLANG
+export HAM_TOOLSET_NAME=clang_18
+export HAM_TOOLSET_DIR="${HAM_HOME}/toolsets/${HAM_TOOLSET_NAME}"
+export HAM_CPP_TOOLSET=$HAM_TOOLSET
+export HAM_CPP_TOOLSET_NAME=$HAM_TOOLSET_NAME
+
+case $HAM_OS in
+  LINUX)
+    toolset_check_and_dl_ver clang_18 lin-x64 v18_1_8 || return 1
+
+    export CLANG_DIR="${HAM_TOOLSET_DIR}/lin-x64"
+    export OSPLAT=X64
+    export BUILD_BIN_LOA=$HAM_BIN_LOA
+
+    if command -v pacman &>/dev/null; then
+      if [ ! -f "/usr/lib/libtinfo.so.5" ]; then
+        log_info "Library /usr/lib/libtinfo.so.5 does not exist. Installing ncurses5-compat-libs from local package."
+        if sudo pacman -U "${CLANG_DIR}/deps/ncurses5-compat-libs-6.5-1-x86_64.pkg.tar.zst" --noconfirm; then
+          log_info "ncurses5-compat-libs installed successfully."
+        else
+          log_error "Failed to install ncurses5-compat-libs."
+          return 1
+        fi
+      fi
+    fi
+    ;;
+  *)
+    echo "E/Toolset: Unsupported host OS"
+    return 1
+    ;;
+esac
+
+pathenv_add "${CLANG_DIR}/bin"
+
+# finding correct clang compiler dir
+dir=$(clang --version | grep InstalledDir)
+export CMD_JSON_COMPILER_PATH=${dir#*' '}/
+
+if ! VER="--- linux_x64 -----------------------
+$(clang -arch x86_64 --version)"; then
+  echo "E/Can't get version."
+  return 1
+fi
+
+export HAM_TOOLSET_VERSIONS="$HAM_TOOLSET_VERSIONS
+$VER"

--- a/specs/toolsets/linux_x64/setup-toolset.sh
+++ b/specs/toolsets/linux_x64/setup-toolset.sh
@@ -12,15 +12,20 @@ esac
 export OSPLAT=X64
 export BUILD_BIN_LOA=$HAM_BIN_LOA
 
-# Clang is the default on Linux, the GCC linker is insane...
-export LINUX_CLANG=${LINUX_CLANG:-1}
+# Default to GCC.
+export LINUX_CLANG=${LINUX_CLANG:-0}
 
 # Use GCC
 if [ "${LINUX_CLANG}" == "0" ]; then
   toolset_import gcc_470 || return 1
 
   VER="--- linux_x64 -----------------------
-Using GCC"
+Using GCC System: $(gcc --version | grep gcc)"
+elif [ "${LINUX_CLANG}" == "18" ]; then
+  toolset_import clang_18 || return 1
+
+  VER="--- linux_x64 -----------------------
+Using Clang 18: $(clang -arch x86_64 --version)"
 else
   # Use clang
   export HAM_TOOLSET=CLANG
@@ -34,7 +39,7 @@ else
   export CMD_JSON_COMPILER_PATH=${dir#*' '}/
 
   if ! VER="--- linux_x64 -----------------------
-$(clang -arch x86_64 --version)"; then
+Using Clang System: $(clang -arch x86_64 --version)"; then
     echo "E/Can't get version."
     return 1
   fi


### PR DESCRIPTION
## Description, Motivation and Context
- bash lib: Added ham_os_package_syslib_check_and_install in ham-bash-lib.sh to simplify installing system libraries using package managers like apt, pacman, and brew.
- bash lib: Added ham-bash-lib-unittest.sh to do simple unittesting of the bash libraries
- ham make: Missing rules or include files are now hard error resulting in immediate build failure.
- toolsets: Add clang_18 toolset which adds Clang 18 as an option on Linux.
- rules/toolkit.ham: In tkBuildPackage fixed issues in the PKGTARGET_LIB dependency tree to streamline library targeting and dependency resolution.
- rules/base.ham: Replaced the hardcoded ham-exec-retry with a new HAM_EXEC_RETRY variable for greater flexibility in retrying execution failures.
- rules/ham-toolset.ham: Modified hamToolsetHdrs to return the correct headers directory it finds during toolset discovery.
- rules/base-GCC-rules.ham: Improved GCC linking behavior by adding -Wl,--no-undefined and -Wl,--start-group/--end-group flags to SharedLink, DllLink, and Link actions, making the linking process more robust.

## How Has This Been Tested?

Command line to run all the tests that I run locally:
```
./_run_ci.sh
```

## Types Of Changes
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that causes existing functionality to change)
* [ ] Documentation (code docs, comments, or changes to the doc systems)
* [x] Testing/Build (test coverage or the test/build subsystems themselves)
* [ ] Packaging (adds examples or modifies a release package)
