### PR TITLE
Pierre: Add Support for Clang 19 and Update Build Configurations in GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_ubuntu:
-    # The type of runner that the job will run on
+  build_ubuntu22:
     runs-on: ubuntu-22.04
 
     steps:
@@ -38,8 +37,30 @@ jobs:
         run: |
           ./bin/ham -X ham _run_ci.sh
 
+  build_ubuntu24:
+    runs-on: ubuntu-24.04
+
+    steps:
+      # Check-out our repository
+      - uses: actions/checkout@v3
+
+      - name: Install OS packages
+        run: |
+          ./bin/ham-install-os-packages
+
+      - name: ham-toolset repos svn default
+        run: |
+          ./bin/ham-toolset repos svn default
+
+      - name: ham-toolset rclone python_3 nodejs php_8
+        run: |
+          ./bin/ham-toolset rclone python_3 nodejs php_8
+
+      - name: _run_ci.sh
+        run: |
+          ./bin/ham -X ham _run_ci.sh
+
   build_macos_latest:
-    # The type of runner that the job will run on
     runs-on: macos-latest
 
     steps:
@@ -63,7 +84,6 @@ jobs:
           ./bin/ham -X ham _run_ci.sh
 
   build_windows_latest:
-    # The type of runner that the job will run on
     runs-on: windows-latest
 
     steps:

--- a/rules/toolkit-base-clang_19.ham
+++ b/rules/toolkit-base-clang_19.ham
@@ -1,0 +1,2 @@
+Import toolkit-base-gcc_470.ham ;
+LOA_LINKER = clang ;

--- a/rules/toolkit-cpp-clang_19.ham
+++ b/rules/toolkit-cpp-clang_19.ham
@@ -1,0 +1,13 @@
+Import toolkit-cpp-clang_33.ham ;
+
+CLANG_CPP_ARGS +=
+  # Disable: warning: variable length arrays in C++ are a Clang extension
+  -Wno-vla-cxx-extension
+;
+
+if $(LINUX) {
+  LINKFLAGS +=
+    # More compatible, should work on Arch/SteamOS & Ubuntu
+    --unwindlib=libgcc
+  ;
+}

--- a/specs/toolsets/clang_18/setup-toolset.sh
+++ b/specs/toolsets/clang_18/setup-toolset.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 toolset_import_once xslt_tools || return 1
 
-# We're using clang...
-export LINUX_CLANG=18
-
 # Use clang
 export HAM_TOOLSET=CLANG
 export HAM_TOOLSET_NAME=clang_18
@@ -14,11 +11,11 @@ export HAM_CPP_TOOLSET_NAME=$HAM_TOOLSET_NAME
 case $HAM_OS in
   LINUX)
     toolset_check_and_dl_ver clang_18 lin-x64 v18_1_8 || return 1
-
     export CLANG_DIR="${HAM_TOOLSET_DIR}/lin-x64"
     export OSPLAT=X64
     export BUILD_BIN_LOA=$HAM_BIN_LOA
 
+    # fixup clang 18, it needs libtinfo.so.5 and ncurses5
     if command -v pacman &>/dev/null; then
       if [ ! -f "/usr/lib/libtinfo.so.5" ]; then
         log_info "Library /usr/lib/libtinfo.so.5 does not exist. Installing ncurses5-compat-libs from local package."
@@ -52,10 +49,13 @@ pathenv_add "${CLANG_DIR}/bin"
 dir=$(clang --version | grep InstalledDir)
 export CMD_JSON_COMPILER_PATH=${dir#*' '}/
 
-if ! VER="--- clang_18 ------------------------
+VER="--- clang_18 ------------------------"
+if [ "$HAM_NO_VER_CHECK" != "1" ]; then
+  if ! VER="$VER
 $(clang -arch x86_64 --version)"; then
-  echo "E/Can't get version."
-  return 1
+    echo "E/Can't get version."
+    return 1
+  fi
 fi
 
 export HAM_TOOLSET_VERSIONS="$HAM_TOOLSET_VERSIONS

--- a/specs/toolsets/clang_19/setup-toolset.sh
+++ b/specs/toolsets/clang_19/setup-toolset.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+toolset_import_once xslt_tools || return 1
+
+export LINUX_CLANG=19
+
+export HAM_TOOLSET=CLANG
+export HAM_TOOLSET_NAME=clang_19
+export HAM_TOOLSET_DIR="${HAM_HOME}/toolsets/${HAM_TOOLSET_NAME}"
+export HAM_CPP_TOOLSET=$HAM_TOOLSET
+export HAM_CPP_TOOLSET_NAME=$HAM_TOOLSET_NAME
+
+case $HAM_OS in
+  LINUX)
+    toolset_check_and_dl_ver clang_19 lin-x64 v19_1_0 || return 1
+    export CLANG_DIR="${HAM_TOOLSET_DIR}/lin-x64"
+    export OSPLAT=X64
+    export BUILD_BIN_LOA=$HAM_BIN_LOA
+    ;;
+  *)
+    echo "E/Toolset: Unsupported host OS"
+    return 1
+    ;;
+esac
+
+pathenv_add "${CLANG_DIR}/bin"
+
+# finding correct clang compiler dir
+dir=$(clang --version | grep InstalledDir)
+export CMD_JSON_COMPILER_PATH=${dir#*' '}/
+
+VER="--- clang_19 ------------------------"
+if [ "$HAM_NO_VER_CHECK" != "1" ]; then
+  if ! VER="$VER
+$(clang -arch x86_64 --version)"; then
+    echo "E/Can't get version."
+    return 1
+  fi
+fi
+
+export HAM_TOOLSET_VERSIONS="$HAM_TOOLSET_VERSIONS
+$VER"

--- a/specs/toolsets/clang_19/setup-toolset.sh
+++ b/specs/toolsets/clang_19/setup-toolset.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 toolset_import_once xslt_tools || return 1
 
-export LINUX_CLANG=19
-
 export HAM_TOOLSET=CLANG
 export HAM_TOOLSET_NAME=clang_19
 export HAM_TOOLSET_DIR="${HAM_HOME}/toolsets/${HAM_TOOLSET_NAME}"

--- a/specs/toolsets/linux_x64/setup-toolset.sh
+++ b/specs/toolsets/linux_x64/setup-toolset.sh
@@ -12,24 +12,36 @@ esac
 export OSPLAT=X64
 export BUILD_BIN_LOA=$HAM_BIN_LOA
 
-# Default to Clang 18 because we install it ourselve so its a reliable well
-# defined version.
-export LINUX_CLANG=${LINUX_CLANG:-18}
+if [ -n "$HAM_LINUX_CLANG" ]; then
+  LINUX_CLANG=$HAM_LINUX_CLANG
+else
+  # Default to Clang 19 redist so we have a well know version by default.
+  LINUX_CLANG=clang_19
+fi
 
 # Use GCC
-if [ "${LINUX_CLANG}" == "0" ]; then
+if [ "${LINUX_CLANG}" == "gcc_system" ]; then
+  ### system gcc ###
   toolset_import gcc_470 || return 1
 
   VER="--- linux_x64 -----------------------
-Using GCC System: $(gcc --version | grep gcc)"
+Using system GCC: $(gcc --version | grep gcc)"
 
-elif [ "${LINUX_CLANG}" == "18" ]; then
+elif [ "${LINUX_CLANG}" == "clang_18" ]; then
+  ### clang 18 ###
   toolset_import clang_18 || return 1
 
   VER="--- linux_x64 -----------------------
-Using Clang 18: $(clang -arch x86_64 --version)"
+Using redist Clang 18: $(clang -arch x86_64 --version | grep version)"
 
-else
+elif [ "${LINUX_CLANG}" == "clang_19" ]; then
+  ### clang 19 ###
+  toolset_import clang_19 || return 1
+
+  VER="--- linux_x64 -----------------------
+Using redist Clang 19: $(clang -arch x86_64 --version | grep version)"
+
+elif [ "${LINUX_CLANG}" == "clang_system" ]; then
   # Use the system clang
   export HAM_TOOLSET=CLANG
   export HAM_TOOLSET_NAME=clang_33
@@ -42,10 +54,15 @@ else
   export CMD_JSON_COMPILER_PATH=${dir#*' '}/
 
   if ! VER="--- linux_x64 -----------------------
-Using Clang System: $(clang -arch x86_64 --version)"; then
+Using system Clang: $(clang -arch x86_64 --version)"; then
     echo "E/Can't get version."
     return 1
   fi
+
+else
+  ### Unkown Linux C/C++ compiler ###
+  log_error "Unknown LINUX_CLANG: '$LINUX_CLANG'."
+  return 1
 fi
 
 export HAM_TOOLSET_VERSIONS="$HAM_TOOLSET_VERSIONS


### PR DESCRIPTION
## Description, Motivation and Context

This PR introduces support for Clang 19 on Linux and updates build configurations for Ubuntu 22.04 and 24.04 in GitHub Actions. 

The changes proposed are as follows:

- Clang 19 support has been added ([ec4a642](https://github.com/user/repo/commit/ec4a642)).
- The setup-toolset.sh script in the linux_x64 toolset has been updated to accommodate the above change ([77d4494](https://github.com/user/repo/commit/77d4494)).
- Updates are made to the clang_18 and clang_19 toolsets ([ef1d651](https://github.com/user/repo/commit/ef1d651)).
- Github Actions has been configured to build on Ubuntu 22.04 and 24.04 to validate these changes across these versions of Ubuntu ([ba32eec](https://github.com/user/repo/commit/ba32eec)).

These updates are important to keep the project's build configurations current and support the latest version of Clang.

## How Has This Been Tested?

The changes have been tested locally on Ubuntu 22.04 and Ubuntu 24.04. Testing involved running the CI script with the command:

```
./_run_ci.sh
```

In addition, the updates to the build configurations have been validated within Github Actions' environments for Ubuntu 22.04 and 24.04.

## Types Of Changes

This PR involves the following types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that causes existing functionality to change)
* [ ] Documentation (code docs, comments, or changes to the doc systems)
* [x] Testing/Build (test coverage or the test/build subsystems themselves)
* [ ] Packaging (adds examples or modifies a release package)
